### PR TITLE
Added "parse_size" for translating all size units

### DIFF
--- a/roocs_utils/utils/common.py
+++ b/roocs_utils/utils/common.py
@@ -1,0 +1,23 @@
+import re
+
+from dask.utils import byte_sizes
+	
+
+def parse_size(size):
+    """
+    Parse size string into number of bytes.
+
+    :param: size [string]
+    :return: integer (number of bytes)
+    """
+    try:
+        n, suffix = re.match('^(\d+\.?\d*)([a-zA-Z]+)$', size).groups()
+        multiplier = byte_sizes[suffix.lower()]
+
+        size_in_bytes = multiplier * float(n)
+    except KeyError as e:
+        raise ValueError(f"Could not interpret '{suffix}' as a byte unit") 
+
+    return size_in_bytes
+
+

--- a/tests/test_utils/test_common.py
+++ b/tests/test_utils/test_common.py
@@ -1,0 +1,17 @@
+from roocs_utils.utils.common import parse_size
+
+
+def test_parse_size():
+
+    tests = [('1000000.0b', 1000000),
+             ('1MiB', 1048576),
+             ('1.0MB', 1000000),
+             ('0.001Gb', 1000000),
+             ('500Mb', 500000000)]
+
+    for test, check in tests:
+        assert(parse_size(test) == check)
+
+
+
+


### PR DESCRIPTION
@ellesmith88 please check this minor addition to roocs-utils and accept if you are happy. I have used the `dask` dictionary of different size units to create a single parser that we can use for all sizes read from config files and/or user input.