### PR TITLE
Changes to match clisops split outputs

### DIFF
--- a/roocs_utils/etc/roocs.ini
+++ b/roocs_utils/etc/roocs.ini
@@ -10,7 +10,7 @@ extra_floats =
 
 [project:cmip5]
 base_dir = /badc/cmip5/data
-file_name_template = {__derive__var_id}_{frequency}_{model_id}_{experiment_id}_r{realization}i{initialization_method}p{physics_version}_{__derive__time_range}.nc
+file_name_template = {__derive__var_id}_{frequency}_{model_id}_{experiment_id}_r{realization}i{initialization_method}p{physics_version}_{__derive__time_range}.{__derive__extension}
 attr_defaults =
     model_id:no-model
     frequency:no-freq
@@ -23,7 +23,7 @@ mappings =
 
 [project:cmip6]
 base_dir = /badc/cmip6/data
-file_name_template = {__derive__var_id}_{table_id}_{source_id}_{experiment_id}_r{realization_index}i{initialization_index}p{physics_index}f{forcing_index}_{grid_label}_{__derive__time_range}.nc
+file_name_template = {__derive__var_id}_{table_id}_{source_id}_{experiment_id}_r{realization_index}i{initialization_index}p{physics_index}f{forcing_index}_{grid_label}_{__derive__time_range}.{__derive__extension}
 attr_defaults =
     table_id:no-table
     source_id:no-model
@@ -39,7 +39,7 @@ mappings =
 
 [project:cordex]
 base_dir = /badc/cordex/data
-file_name_template = {__derive__var_id}_{CORDEX_domain}_{driving_model_id}_{experiment}_{driving_model_ensemble_member}_{model_id}_{rcm_version_id}_{frequency}_{__derive__time_range}.nc
+file_name_template = {__derive__var_id}_{CORDEX_domain}_{driving_model_id}_{experiment}_{driving_model_ensemble_member}_{model_id}_{rcm_version_id}_{frequency}_{__derive__time_range}.{__derive__extension}
 attr_defaults =
     CORDEX_domain:no-domain
     driving_model_id:no-driving-model
@@ -53,7 +53,7 @@ mappings =
 
 [project:c3s-cmip5]
 base_dir = /group_workspaces/jasmin2/cp4cds1/vol1/data/
-file_name_template = {__derive__var_id}_{frequency}_{model_id}_{experiment_id}_r{realization}i{initialization_method}p{physics_version}_{__derive__time_range}.nc
+file_name_template = {__derive__var_id}_{frequency}_{model_id}_{experiment_id}_r{realization}i{initialization_method}p{physics_version}_{__derive__time_range}.{__derive__extension}
 attr_defaults =
     model_id:no-model
     frequency:no-freq
@@ -67,7 +67,7 @@ mappings =
 [project:c3s-cmip6]
 base_dir = NOT DEFINED YET
 # these may need to be changed
-file_name_template = {__derive__var_id}_{table_id}_{source_id}_{experiment_id}_r{realization_index}i{initialization_index}p{physics_index}f{forcing_index}_{grid_label}_{__derive__time_range}.nc
+file_name_template = {__derive__var_id}_{table_id}_{source_id}_{experiment_id}_r{realization_index}i{initialization_index}p{physics_index}f{forcing_index}_{grid_label}_{__derive__time_range}.{__derive__extension}
 attr_defaults =
     table_id:no-table
     source_id:no-model
@@ -82,7 +82,7 @@ mappings =
 
 [project:c3s-cordex]
 base_dir = /group_workspaces/jasmin2/cp4cds1/vol1/data/
-file_name_template = {__derive__var_id}_{CORDEX_domain}_{driving_model_id}_{experiment}_{driving_model_ensemble_member}_{model_id}_{rcm_version_id}_{frequency}_{__derive__time_range}.nc
+file_name_template = {__derive__var_id}_{CORDEX_domain}_{driving_model_id}_{experiment}_{driving_model_ensemble_member}_{model_id}_{rcm_version_id}_{frequency}_{__derive__time_range}.{__derive__extension}
 attr_defaults =
     CORDEX_domain:no-domain
     driving_model_id:no-driving-model

--- a/roocs_utils/parameter/parameterise.py
+++ b/roocs_utils/parameter/parameterise.py
@@ -11,7 +11,9 @@ from roocs_utils.parameter import (
 def parameterise(collection=None, area=None, level=None, time=None):
 
     # if collection is a dataset/dataarray it doesn't need to be parameterised
-    if type(collection) not in (xr.core.dataarray.DataArray, xr.core.dataset.Dataset):
+    if type(collection) not in (xr.core.dataarray.DataArray, xr.core.dataset.Dataset) \
+        and collection is not None:
+
         collection = collection_parameter.CollectionParameter(collection)
 
     area = area_parameter.AreaParameter(area)

--- a/roocs_utils/parameter/parameterise.py
+++ b/roocs_utils/parameter/parameterise.py
@@ -11,9 +11,7 @@ from roocs_utils.parameter import (
 def parameterise(collection=None, area=None, level=None, time=None):
 
     # if collection is a dataset/dataarray it doesn't need to be parameterised
-    if type(collection) not in (xr.core.dataarray.DataArray, xr.core.dataset.Dataset) \
-        and collection is not None:
-
+    if type(collection) not in (xr.core.dataarray.DataArray, xr.core.dataset.Dataset):
         collection = collection_parameter.CollectionParameter(collection)
 
     area = area_parameter.AreaParameter(area)

--- a/roocs_utils/parameter/time_parameter.py
+++ b/roocs_utils/parameter/time_parameter.py
@@ -23,12 +23,12 @@ class TimeParameter(_BaseParameter):
         if start is not None:
             start = (
                 date_parser.parse(start, default=datetime.datetime(2005, 1, 1))
-                .isoformat()
+                .isoformat().split('-')[0]
             )
         if end is not None:
             end = (
                 date_parser.parse(end, default=datetime.datetime(2005, 12, 30))
-                .isoformat()
+                .isoformat().split('-')[0]
             )
 
         return start, end

--- a/roocs_utils/parameter/time_parameter.py
+++ b/roocs_utils/parameter/time_parameter.py
@@ -23,12 +23,12 @@ class TimeParameter(_BaseParameter):
         if start is not None:
             start = (
                 date_parser.parse(start, default=datetime.datetime(2005, 1, 1))
-                .isoformat().split('-')[0]
+                .isoformat()
             )
         if end is not None:
             end = (
                 date_parser.parse(end, default=datetime.datetime(2005, 12, 30))
-                .isoformat().split('-')[0]
+                .isoformat()
             )
 
         return start, end

--- a/roocs_utils/parameter/time_parameter.py
+++ b/roocs_utils/parameter/time_parameter.py
@@ -24,13 +24,11 @@ class TimeParameter(_BaseParameter):
             start = (
                 date_parser.parse(start, default=datetime.datetime(2005, 1, 1))
                 .isoformat()
-                .split("-")[0]
             )
         if end is not None:
             end = (
                 date_parser.parse(end, default=datetime.datetime(2005, 12, 30))
                 .isoformat()
-                .split("-")[0]
             )
 
         return start, end

--- a/roocs_utils/utils/common.py
+++ b/roocs_utils/utils/common.py
@@ -1,7 +1,7 @@
 import re
 
 from dask.utils import byte_sizes
-	
+
 
 def parse_size(size):
     """
@@ -10,8 +10,10 @@ def parse_size(size):
     :param: size [string]
     :return: integer (number of bytes)
     """
+    n, suffix = re.match('^(\d+\.?\d*)([a-zA-Z]+)$', size).groups()
+
     try:
-        n, suffix = re.match('^(\d+\.?\d*)([a-zA-Z]+)$', size).groups()
+
         multiplier = byte_sizes[suffix.lower()]
 
         size_in_bytes = multiplier * float(n)

--- a/roocs_utils/xarray_utils/xarray_utils.py
+++ b/roocs_utils/xarray_utils/xarray_utils.py
@@ -69,16 +69,21 @@ def get_coord_type(coord):
 
 
 def get_main_variable(dset):
+
     data_dims = [data.dims for var_id, data in dset.variables.items()]
     flat_dims = [dim for sublist in data_dims for dim in sublist]
+
     results = {}
+
     for var_id, data in dset.variables.items():
+
         if var_id in flat_dims:
             continue
         if "bnd" in var_id:
             continue
         else:
             results.update({var_id: data.dims})
+
     result = max(results, key=results.get)
 
     if result is None:

--- a/tests/test_parameter/test_time_parameter.py
+++ b/tests/test_parameter/test_time_parameter.py
@@ -10,8 +10,8 @@ def test__str__():
     parameter = TimeParameter(time)
     assert (
         parameter.__str__() == "Time period to subset over"
-        f"\n start time: 2085"
-        f"\n end time: 2120"
+        f"\n start time: 2085-01-01T12:00:00+00:00"
+        f"\n end time: 2120-12-30T12:00:00+00:00"
     )
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
@@ -60,25 +60,25 @@ def test_validate_error_no_slash():
 def test_trailing_slash():
     time = "2085-01-01T12:00:00Z/"
     parameter = TimeParameter(time)
-    assert parameter.tuple == ("2085", None)
+    assert parameter.tuple == ("2085-01-01T12:00:00+00:00", None)
 
 
 def test_starting_slash():
     time = "/2120-12-30T12:00:00Z"
     parameter = TimeParameter(time)
-    assert parameter.tuple == (None, "2120")
+    assert parameter.tuple == (None, "2120-12-30T12:00:00+00:00")
 
 
 def test_tuple():
     time = "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z"
     parameter = TimeParameter(time)
-    assert parameter.tuple == ("2085", "2120")
+    assert parameter.tuple == ("2085-01-01T12:00:00+00:00", "2120-12-30T12:00:00+00:00")
 
 
 def test_as_dict():
     time = "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z"
     parameter = TimeParameter(time)
-    assert parameter.asdict() == {"start_time": "2085", "end_time": "2120"}
+    assert parameter.asdict() == {"start_time": "2085-01-01T12:00:00+00:00", "end_time": "2120-12-30T12:00:00+00:00"}
 
 
 def test_slash_none():
@@ -103,11 +103,11 @@ def test_empty_string():
 def test_white_space():
     time = "2085-01-01T12:00:00Z / 2120-12-30T12:00:00Z "
     parameter = TimeParameter(time)
-    assert parameter.tuple == ("2085", "2120")
+    assert parameter.tuple == ("2085-01-01T12:00:00+00:00", "2120-12-30T12:00:00+00:00")
 
 
 def test_class_instance():
     time = "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z"
     parameter = TimeParameter(time)
     new_parameter = TimeParameter(parameter)
-    assert new_parameter.tuple == ("2085", "2120")
+    assert new_parameter.tuple == ("2085-01-01T12:00:00+00:00", "2120-12-30T12:00:00+00:00")


### PR DESCRIPTION
Can't remove `.split('-')[0]` in `TimeParameter` yet as the changes to allow a full date to be passed through have not been implemented yet. So removing `.split('-')[0]` will cause problems in daops and clisops until this fix has been implemented