### PR TITLE
Replace cfunits by cftime and cf_xarray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ jobs:
         apt:
           packages:
             - libspatialindex-dev
-            - libudunits2-dev
     - env: TOXENV=py38
       name: "Python3.8 (Linux)"
       python: 3.8
@@ -38,7 +37,6 @@ jobs:
         apt:
           packages:
             - libspatialindex-dev
-            - libudunits2-dev
             - libnetcdf-dev
             - libhdf5-dev
     - env: TOXENV=py38-anaconda
@@ -96,7 +94,6 @@ jobs:
           packages:
             - netcdf
             - spatialindex
-            - udunits
             - python@3.8
       before_install:
         - printenv
@@ -109,7 +106,6 @@ jobs:
         apt:
           packages:
             - libspatialindex-dev
-            - libudunits2-dev
     - env: TOXENV=py36
       name: "Python3.6 (Linux)"
       python: 3.6
@@ -117,7 +113,6 @@ jobs:
         apt:
           packages:
             - libspatialindex-dev
-            - libudunits2-dev
   allow_failures:
       - env: TOXENV=black
       - env: TOXENV=py38-anaconda

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ Contributors
 
 * Eleanor Smith eleanor.smith@stfc.ac.uk
 * Carsten Ehbrecht ehbrecht@dkrz.de
+* Pascal Bourgault pascal.bourgault@gmail.com

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,15 @@
 Version History
 ===============
+
+v0.1.5 (unreleased)
+-------------------
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
+
+* Replaced use of ``cfunits`` by ``cf_xarray`` and ``cftime`` (new dependency) in ``roocs_utils.xarray_utils``.
+
+
 v0.1.4 (2020-10-22)
 -------------------
 

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,1 +1,0 @@
-libudunits2-dev

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,8 +11,7 @@ dependencies:
 - numpy>=1.16
 - xarray>=0.15
 - dask>=2.6
-- udunits2>=2.2
-- cfunits>=3.2.7
+- cftime
 - python-dateutil>=2.8.1
 - cf_xarray>=0.2.1 # Note that conda-forge package is cf_xarray (!= cf-xarray)
 - netCDF4>=1.4

--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,7 @@ dependencies:
  - numpy>=1.16
  - xarray>=0.15
  - dask>=2.6
- - udunits2>=2.2
- - cfunits>=3.2.7
+ - cftime
  - python-dateutil>=2.8.1
  - cf_xarray>=0.2.1 # Note that conda-forge package is cf_xarray (!= cf-xarray)
  - netCDF4>=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
+cftime
 numpy>=1.16
 xarray>=0.15
 dask[complete]>=2.6
-cfunits>=3.2.7
 netCDF4>=1.4
 python-dateutil>=2.8.1
 cf-xarray>=0.2.1


### PR DESCRIPTION
This removes `cfunits` and `udunits` as dependencies and replaces them in the code with `cftime` (new dependency) and `cf_xarray`.

Hi! I am not a user of `roocs_utils`, but I do use `clisops` and am a maintainer of `xclim`. Currently, our xclim builds are broken because of the new dependency of `clisops` to `roocs_utils`, but it all goes down to  `cfunits` and its dependency on `udunits`, which is not installable through pip.

I saw that the use of `cfunits` in the package was quite limited and could be easily replaced by calls to `cf_xarray`.  To cover all cases, I needed to use `cftime` which I added to the requirements. But this shouldn't be a problem as it was already implicitly needed. 

The changes were easy to do, so I went directly to this PR instead of opening an issue first, sorry about that. If this removal of cfunits is not wanted, feel free to close this PR, we will find another solution to our build problems in xclim.