### PR TITLE
Resolve urls

### DIFF
--- a/roocs_utils/etc/roocs.ini
+++ b/roocs_utils/etc/roocs.ini
@@ -116,7 +116,6 @@ inventory_pickle =  %(inventory_dir)s/%(project_name)s-inventory.pickle
 full_inventory_file = %(inventory_dir)s/%(project_name)s-inventory-files.yml
 c3s_inventory_file = %(inventory_dir)s/%(project_name)s-inventory.yml
 data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6/
-inventory_url = https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/master/inventories/c3s-cmip6/c3s-cmip6_files_latest.yml
 
 [project:c3s-cordex]
 project_name = c3s-cordex

--- a/roocs_utils/etc/roocs.ini
+++ b/roocs_utils/etc/roocs.ini
@@ -65,7 +65,6 @@ mappings =
     project:project_id
 use_inventory = False
 
-
 [project:c3s-cmip5]
 project_name = c3s-cmip5
 base_dir = /gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5
@@ -89,7 +88,6 @@ error_pickle =  %(inventory_dir)s/%(project_name)s-errors.pickle
 inventory_pickle =  %(inventory_dir)s/%(project_name)s-inventory.pickle
 full_inventory_file = %(inventory_dir)s/%(project_name)s-inventory-files.yml
 c3s_inventory_file = %(inventory_dir)s/%(project_name)s-inventory.yml
-
 
 [project:c3s-cmip6]
 project_name = c3s-cmip6
@@ -117,6 +115,8 @@ error_pickle =  %(inventory_dir)s/%(project_name)s-errors.pickle
 inventory_pickle =  %(inventory_dir)s/%(project_name)s-inventory.pickle
 full_inventory_file = %(inventory_dir)s/%(project_name)s-inventory-files.yml
 c3s_inventory_file = %(inventory_dir)s/%(project_name)s-inventory.yml
+data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6/
+inventory_url = https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/master/inventories/c3s-cmip6/c3s-cmip6_files_latest.yml
 
 [project:c3s-cordex]
 project_name = c3s-cordex

--- a/roocs_utils/parameter/base_parameter.py
+++ b/roocs_utils/parameter/base_parameter.py
@@ -3,6 +3,7 @@ from pydoc import locate
 
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.exceptions import MissingParameterValue
+from roocs_utils.utils.file_utils import FileMapper
 
 
 class _BaseParameter(object):
@@ -25,8 +26,12 @@ class _BaseParameter(object):
         return self.input
 
     def _parse(self):
+
         if isinstance(self.input, self.__class__):
             return self.input._parse()
+
+        elif isinstance(self.input, FileMapper):
+            return self.input
 
         else:
             return getattr(self, self.parse_method)()

--- a/roocs_utils/parameter/base_parameter.py
+++ b/roocs_utils/parameter/base_parameter.py
@@ -30,9 +30,6 @@ class _BaseParameter(object):
         if isinstance(self.input, self.__class__):
             return self.input._parse()
 
-        elif isinstance(self.input, FileMapper):
-            return self.input
-
         else:
             return getattr(self, self.parse_method)()
 
@@ -73,6 +70,9 @@ class _BaseParameter(object):
         # check str or bytes
         elif isinstance(self.input, (str, bytes)):
             sequence = [x.strip() for x in self.input.split(",")]
+
+        elif isinstance(self.input, FileMapper):
+            return [self.input]
 
         elif isinstance(self.input, Sequence):
             sequence = self.input

--- a/roocs_utils/parameter/collection_parameter.py
+++ b/roocs_utils/parameter/collection_parameter.py
@@ -11,8 +11,9 @@ class CollectionParameter(_BaseParameter):
     | A collection can be input as:
     | A string of comma separated values: "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga,cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
     | A sequence of strings: e.g. ("cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga", "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga")
+    | A sequence of roocs_utils.utils.file_utils.FileMapper objects
 
-    Validates the input and parses the ids.
+    Validates the input and parses the items.
 
     """
 
@@ -22,22 +23,21 @@ class CollectionParameter(_BaseParameter):
         if self._result is None:
             raise MissingParameterValue(f"{self.__class__.__name__} must be provided")
 
-        self._parse_ids()
+        self._parse_items()
 
-    def _parse_ids(self):
-        if isinstance(self._result, FileMapper):
-            return [self._result]
-
+    def _parse_items(self):
         for value in self._result:
-            if not isinstance(value, str):
-                raise InvalidParameterValue("Each id in a collection must be a string")
+            if not isinstance(value, str or FileMapper):
+                raise InvalidParameterValue(
+                    f"Each id in a collection must be a string or an instance of {FileMapper}"
+                )
 
         return tuple(self._result)
 
     @property
     def tuple(self):
-        """ Returns a tuple of the collection ids """
-        return self._parse_ids()
+        """ Returns a tuple of the collection items """
+        return self._parse_items()
 
     def __str__(self):
         string = "Datasets to analyse:"

--- a/roocs_utils/parameter/collection_parameter.py
+++ b/roocs_utils/parameter/collection_parameter.py
@@ -1,6 +1,7 @@
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.exceptions import MissingParameterValue
 from roocs_utils.parameter.base_parameter import _BaseParameter
+from roocs_utils.utils.file_utils import FileMapper
 
 
 class CollectionParameter(_BaseParameter):
@@ -24,6 +25,9 @@ class CollectionParameter(_BaseParameter):
         self._parse_ids()
 
     def _parse_ids(self):
+        if isinstance(self._result, FileMapper):
+            return [self._result]
+
         for value in self._result:
             if not isinstance(value, str):
                 raise InvalidParameterValue("Each id in a collection must be a string")

--- a/roocs_utils/parameter/collection_parameter.py
+++ b/roocs_utils/parameter/collection_parameter.py
@@ -27,7 +27,7 @@ class CollectionParameter(_BaseParameter):
 
     def _parse_items(self):
         for value in self._result:
-            if not isinstance(value, str or FileMapper):
+            if not (isinstance(value, str) or isinstance(value, FileMapper)):
                 raise InvalidParameterValue(
                     f"Each id in a collection must be a string or an instance of {FileMapper}"
                 )

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -49,6 +49,7 @@ class DatasetMapper:
     def _deduce_project(self):
 
         if isinstance(self.dset, str):
+
             if self.dset.startswith("/"):
                 # by default this returns c3s-cmip6 not cmip6 (as they have the same base_dir)
                 base_dirs_dict = self._get_base_dirs_dict()
@@ -91,20 +92,26 @@ class DatasetMapper:
 
         # if a file, group of files or directory to files - find files
         if self.dset.startswith("/") or self.dset.endswith(".nc"):
+            # if we have a set of files
+            if self.dset.endswith("}"):
+                dset = self.dset.split("/{")[0]
+
+                files = self.dset.split("/{")[1]
+
             if self.dset.endswith(".nc"):
                 if self.dset.endswith("*.nc"):
                     self._files = sorted(glob.glob(self.dset))
                 else:
                     self._files.append(self.dset)
                 # remove file extension to create data_path
-                self.dset = "/".join(self.dset.split("/")[:-1])
+                dset = "/".join(self.dset.split("/")[:-1])
 
-            self._data_path = self.dset
+            self._data_path = dset
 
             # if base_dir identified, insert into data_path
             if self._base_dir:
                 self._ds_id = ".".join(
-                    self.dset.replace(self._base_dir, self._project)
+                    self._data_path.replace(self._base_dir, self._project)
                     .strip("/")
                     .split("/")
                 )

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -21,7 +21,7 @@ class DatasetMapper:
         | A file path: e.g. "/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/tas_Amon_HadGEM2-ES_rcp85_r1i1p1_200512-203011.nc"
         | A path to a group of files: e.g. "/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc" or "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/{tas_day_MIROC6_amip_r1i1p1f1_gn_19790101-19881231.nc;tas_day_MIROC6_amip_r1i1p1f1_gn_19890101-19981231.nc}"
         | A directory e.g. "/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas"
-
+        | An instance of the FileMapper class (that represents a set of files within a single directory)
 
         When force=True, if the project can not be identified, any attempt to use the base_dir of a project
         to resolve the data path will be ignored. Any of data_path, ds_id and files that can be set, will be set.

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -121,7 +121,7 @@ class DatasetMapper:
             if self.dset.endswith("}"):
                 self._data_path = self.dset.split("/{")[0]
 
-                files = self.dset.split("/{")[1].strip("}").split(",")
+                files = self.dset.split("/{")[1].strip("}").split(";")
                 self._files = [os.path.join(self._data_path, f) for f in files]
 
             if self.dset.endswith(".nc"):
@@ -178,6 +178,10 @@ class DatasetMapper:
 
 def derive_dset(dset):
     return DatasetMapper(dset).data_path
+
+
+def derive_ds_id(dset):
+    return DatasetMapper(dset).ds_id
 
 
 def datapath_to_dsid(datapath):

--- a/roocs_utils/utils/file_utils.py
+++ b/roocs_utils/utils/file_utils.py
@@ -1,0 +1,42 @@
+import os
+
+from roocs_utils import CONFIG
+from roocs_utils.exceptions import InvalidProject
+
+
+class FileMapper:
+    def __init__(self, file_list, dirpath=None):
+        self.dirpath = dirpath
+        self.file_list = file_list
+
+        self._resolve()
+
+    def _resolve(self):
+        if not self.dirpath:
+            first_dir = os.path.dirname(self.file_list[0])
+            if os.path.dirname(os.path.commonprefix(self.file_list)) == first_dir:
+                self.dirpath = first_dir
+            else:
+                raise Exception(
+                    "File inputs are not from the same directory so cannot be resolved."
+                )
+
+        self.file_list = [os.path.basename(fpath) for fpath in self.file_list]
+        self.file_paths = [
+            os.path.join(self.dirpath, fname) for fname in self.file_list
+        ]
+
+        # check all files exist on file system
+        if not all(os.path.isfile(file) for file in self.file_paths):
+            raise FileNotFoundError("Some files could not be found.")
+
+
+def is_file_list(coll):
+    # check if collection is a list of files
+    if not isinstance(coll, list):
+        raise Exception(f"Expected collection as a list, have received {type(coll)}")
+
+    if coll[0].startswith("/") or coll[0].startswith("http"):
+        return True
+
+    return False

--- a/roocs_utils/utils/file_utils.py
+++ b/roocs_utils/utils/file_utils.py
@@ -25,7 +25,6 @@ class FileMapper:
         self.file_paths = [
             os.path.join(self.dirpath, fname) for fname in self.file_list
         ]
-
         # check all files exist on file system
         if not all(os.path.isfile(file) for file in self.file_paths):
             raise FileNotFoundError("Some files could not be found.")

--- a/roocs_utils/xarray_utils/xarray_utils.py
+++ b/roocs_utils/xarray_utils/xarray_utils.py
@@ -7,7 +7,7 @@ import cftime
 import numpy as np
 import xarray as xr
 
-from ..project_utils import dset_to_filepaths
+from roocs_utils.project_utils import dset_to_filepaths
 
 known_coord_types = ["time", "level", "latitude", "longitude"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ ignore =
 test = pytest
 
 [tool:pytest]
-;addopts = --verbose tests/
+addopts = --verbose tests/
 filterwarnings = 
 	ignore::UserWarning
 markers = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ ignore =
 test = pytest
 
 [tool:pytest]
-addopts = --verbose tests/
+;addopts = --verbose tests/
 filterwarnings = 
 	ignore::UserWarning
 markers = 

--- a/tests/test_parameter/test_collection_parameter.py
+++ b/tests/test_parameter/test_collection_parameter.py
@@ -39,7 +39,10 @@ def test_validate_error_id():
 
     with pytest.raises(InvalidParameterValue) as exc:
         CollectionParameter(collection)
-    assert str(exc.value) == "Each id in a collection must be a string"
+    assert (
+        str(exc.value) == "Each id in a collection must be a string or "
+        "an instance of <class 'roocs_utils.utils.file_utils.FileMapper'>"
+    )
 
 
 def test_string():

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -213,7 +213,7 @@ def test_unknown_fpath_no_force():
 def test_dataset_mapper_glob():
     dset = (
         "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/"
-        "{tas_day_MIROC6_amip_r1i1p1f1_gn_19790101-19881231.nc,tas_day_MIROC6_amip_r1i1p1f1_gn_19890101-19981231.nc}"
+        "{tas_day_MIROC6_amip_r1i1p1f1_gn_19790101-19881231.nc;tas_day_MIROC6_amip_r1i1p1f1_gn_19890101-19981231.nc}"
     )
     dm = DatasetMapper(dset)
 

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -49,6 +49,14 @@ def test_get_project_name(load_test_data):
     project = get_project_name(dset)
     assert project == "c3s-cmip6"
 
+    dset = (
+        "https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6"
+        "/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803"
+        "/rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
+    )
+    project = get_project_name(dset)
+    assert project == "c3s-cmip6"
+
 
 def test_get_project_name_badc():
     dset = "/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc"
@@ -209,8 +217,36 @@ def test_dataset_mapper_glob():
     )
     dm = DatasetMapper(dset)
 
-    print(dm.files)
-    print(dm.data_path)
-    print(dm.ds_id)
+    assert dm.files == [
+        "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest"
+        "/tas_day_MIROC6_amip_r1i1p1f1_gn_19790101-19881231.nc",
+        "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest"
+        "/tas_day_MIROC6_amip_r1i1p1f1_gn_19890101-19981231.nc",
+    ]
+    assert (
+        dm.data_path
+        == "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest"
+    )
+    assert dm.ds_id == "c3s-cmip6.CMIP.MIROC.MIROC6.amip.r1i1p1f1.day.tas.gn.latest"
 
-    print(sorted(glob.glob(dset)))
+
+def test_url_map_dataset():
+    dset = (
+        "https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6"
+        "/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803"
+        "/rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
+    )
+
+    dm = DatasetMapper(dset)
+    assert dm.files == [
+        "/badc/cmip6/data/CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1"
+        "/Amon/rlds/gr/v20180803/rlds_Amon_IPSL-CM6A-LR_historical_r1i1p1f1_gr_185001-201412.nc"
+    ]
+    assert (
+        dm.data_path
+        == "/badc/cmip6/data/CMIP6/CMIP/IPSL/IPSL-CM6A-LR/historical/r1i1p1f1/Amon/rlds/gr/v20180803"
+    )
+    assert (
+        dm.ds_id
+        == "c3s-cmip6.CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Amon.rlds.gr.v20180803"
+    )

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -1,3 +1,4 @@
+import glob
 import os
 
 import pytest
@@ -199,3 +200,17 @@ def test_unknown_fpath_no_force():
         str(exc.value)
         == "The project could not be identified and force was set to false"
     )
+
+
+def test_dataset_mapper_glob():
+    dset = (
+        "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/"
+        "{tas_day_MIROC6_amip_r1i1p1f1_gn_19790101-19881231.nc,tas_day_MIROC6_amip_r1i1p1f1_gn_19890101-19981231.nc}"
+    )
+    dm = DatasetMapper(dset)
+
+    print(dm.files)
+    print(dm.data_path)
+    print(dm.ds_id)
+
+    print(sorted(glob.glob(dset)))

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -204,6 +204,7 @@ def test_unknown_fpath_no_force():
     )
 
 
+@pytest.mark.skipif(os.path.isdir("/badc") is False, reason="data not available")
 def test_FileMapper():
     file_paths = [
         "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/"

--- a/tests/test_utils/test_file_utils.py
+++ b/tests/test_utils/test_file_utils.py
@@ -1,0 +1,79 @@
+import os
+
+import pytest
+
+from roocs_utils.utils.file_utils import FileMapper
+from roocs_utils.utils.file_utils import is_file_list
+
+
+@pytest.mark.skipif(os.path.isdir("/badc") is False, reason="data not available")
+def test_file_mapper():
+    file_paths = [
+        "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/"
+        "tas_day_MIROC6_amip_r1i1p1f1_gn_19790101-19881231.nc",
+        "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/"
+        "tas_day_MIROC6_amip_r1i1p1f1_gn_19890101-19981231.nc",
+    ]
+    fm = FileMapper(file_paths)
+
+    assert (
+        fm.dirpath
+        == "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest"
+    )
+    assert fm.file_paths == file_paths
+    assert fm.file_list == [
+        "tas_day_MIROC6_amip_r1i1p1f1_gn_19790101-19881231.nc",
+        "tas_day_MIROC6_amip_r1i1p1f1_gn_19890101-19981231.nc",
+    ]
+
+
+def test_file_mapper_different_dirpath():
+    file_paths = [
+        "/badc/cmip6/data/CMIP6/CMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/"
+        "tas_day_MIROC6_amip_r1i1p1f1_gn_19790101-19881231.nc",
+        "/badc/cmip6/data/CMIP6/ScenarioMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/"
+        "tas_day_MIROC6_amip_r1i1p1f1_gn_19890101-19981231.nc",
+    ]
+
+    with pytest.raises(Exception) as exc:
+        FileMapper(file_paths)
+    assert (
+        str(exc.value)
+        == "File inputs are not from the same directory so cannot be resolved."
+    )
+
+
+@pytest.mark.skipif(os.path.isdir("/badc") is False, reason="data not available")
+def test_file_mapper_fake_files():
+    file_paths = [
+        "/badc/cmip6/data/CMIP6/ScenarioMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/"
+        "tas_day_MIROC6_amip_r1i1p1f1_gn_19790101-19881231.nc",
+        "/badc/cmip6/data/CMIP6/ScenarioMIP/MIROC/MIROC6/amip/r1i1p1f1/day/tas/gn/latest/"
+        "tas_day_MIROC6_amip_r1i1p1f1_gn_19890101-19981231.nc",
+    ]
+
+    with pytest.raises(FileNotFoundError) as exc:
+        FileMapper(file_paths)
+    assert str(exc.value) == "Some files could not be found."
+
+
+def test_is_file_list():
+
+    coll = ["/badc/cmip6/fake1.nc", "/badc/cmip6/fake2.nc"]
+    assert is_file_list(coll) is True
+
+    coll = [
+        "https://data.mips.copernicus-climate.eu/cmip6/fake1.nc",
+        "https://data.mips.copernicus-climate.eu/badc/cmip6/fake2.nc",
+    ]
+    assert is_file_list(coll) is True
+
+    coll = ["fake1.nc", "/badc/cmip6/fake2.nc"]
+    assert is_file_list(coll) is False
+
+    with pytest.raises(Exception) as exc:
+        coll = "/badc/cmip6/fake1.nc"
+        is_file_list(coll)
+    assert (
+        str(exc.value) == "Expected collection as a list, have received <class 'str'>"
+    )


### PR DESCRIPTION
Changes to allow DatasetMapper to handle URLs as well as glob pattern such as `"/badc/cmip6/data/.../foo/baa/{full_file_name_1.nc;full_file_name_2.nc}"`