### PR TITLE
Add fixed path mappings

### DIFF
--- a/roocs_utils/etc/roocs.ini
+++ b/roocs_utils/etc/roocs.ini
@@ -1,6 +1,6 @@
 [config_data_types]
 lists = facet_rule
-dicts = mappings attr_defaults
+dicts = mappings attr_defaults fixed_path_mappings
 ints = n_per_batch
 floats =
 boolean = use_inventory is_default_for_path

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -114,7 +114,7 @@ class DatasetMapper:
         elif self._is_ds_id():
             self._ds_id = self.dset
 
-            mappings = CONFIG[f"project:{self.project}"].get("fixed_path_mappings", {})
+            mappings = CONFIG.get(f"project:{self.project}", {}).get("fixed_path_mappings", {})
 
             # If the dataset uses a fixed path mapping (from the config file) then use it
             if self._ds_id in mappings:

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -96,6 +96,7 @@ class DatasetMapper:
                     self._files = sorted(glob.glob(self.dset))
                 else:
                     self._files.append(self.dset)
+
                 # remove file extension to create data_path
                 self.dset = "/".join(self.dset.split("/")[:-1])
 
@@ -112,12 +113,20 @@ class DatasetMapper:
         # test if dataset id
         elif self._is_ds_id():
             self._ds_id = self.dset
+
             mappings = CONFIG[f"project:{self.project}"].get("fixed_path_mappings", {})
+
+            # If the dataset uses a fixed path mapping (from the config file) then use it
             if self._ds_id in mappings:
                 data_path = mappings[self._ds_id]
                 self._data_path = os.path.join(
                     self._base_dir, data_path
                 )
+
+                # Use pattern of fixed file mapping as glob pattern 
+                self._files = sorted(glob.glob(self._data_path))
+
+            # Default mapping is done by converting '.' characters to '/' separators in path
             else:
                 self._data_path = os.path.join(
                     self._base_dir, "/".join(self.dset.split(".")[1:])

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -112,9 +112,16 @@ class DatasetMapper:
         # test if dataset id
         elif self._is_ds_id():
             self._ds_id = self.dset
-            self._data_path = os.path.join(
-                self._base_dir, "/".join(self.dset.split(".")[1:])
-            )
+            mappings = CONFIG[f"project:{self.project}"].get("fixed_path_mappings", {})
+            if self._ds_id in mappings:
+                data_path = mappings[self._ds_id]
+                self._data_path = os.path.join(
+                    self._base_dir, data_path
+                )
+            else:
+                self._data_path = os.path.join(
+                    self._base_dir, "/".join(self.dset.split(".")[1:])
+                )
 
         # use to data_path to find files if not set already
         if len(self._files) < 1:

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -16,8 +16,8 @@ def write_roocs_cfg():
     [project:proj_test]
     base_dir = /projects/test/proj
     fixed_path_mappings =
-        proj_test.my.first.test:first/file.txt
-        proj_test.my.second.test:second/*.txt
+        proj_test.my.first.test:first/test/something.nc
+        proj_test.my.second.test:second/test/data_*.txt
     """
     cfg = Template(cfg_templ).render(base_dir=MINI_ESGF_CACHE_DIR)
     with open(ROOCS_CFG, "w") as fp:

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -12,6 +12,12 @@ def write_roocs_cfg():
     cfg_templ = """
     [project:c3s-cmip5]
     base_dir = {{ base_dir }}/master/test_data/gws/nopw/j04/cp4cds1_vol1/data/c3s-cmip5
+
+    [project:proj_test]
+    base_dir = /projects/test/proj
+    fixed_path_mappings =
+        proj_test.my.first.test:first/file.txt
+        proj_test.my.second.test:second/*.txt
     """
     cfg = Template(cfg_templ).render(base_dir=MINI_ESGF_CACHE_DIR)
     with open(ROOCS_CFG, "w") as fp:

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -211,3 +211,14 @@ def test_unknown_fpath_no_force():
         str(exc.value)
         == "The project could not be identified and force was set to false"
     )
+
+
+def test_unknown_project_no_force():
+    dset = "unknown_project.data1.data2.data3.data4"
+
+    with pytest.raises(InvalidProject) as exc:
+        DatasetMapper(dset)
+    assert (
+        str(exc.value)
+        == "The project could not be identified and force was set to false"
+    )

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -224,6 +224,7 @@ def test_unknown_project_no_force():
     assert (
         str(exc.value)
         == "The project could not be identified and force was set to false"
+    )
 
 
 @pytest.mark.skipif(os.path.isdir("/badc") is False, reason="data not available")

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -99,6 +99,16 @@ class TestDatasetMapper:
             "/siconc_SImon_CESM2_historical_r1i1p1f1_gn_185001-201412.nc"
         ]
 
+    def test_fixed_path_mappings(self):
+        dsm = DatasetMapper('proj_test.my.first.test')
+        assert dsm._data_path == '/projects/test/proj/first/file.txt'
+
+        dsm = DatasetMapper('proj_test.my.second.test')
+        assert dsm._data_path == '/projects/test/proj/second/*.txt'
+
+        dsm = DatasetMapper('proj_test.my.unknown')
+        assert dsm._data_path == '/projects/test/proj/my/unknown'
+
 
 @pytest.mark.skipif(os.path.isdir("/badc") is False, reason="data not available")
 def test_get_filepaths():

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -101,10 +101,12 @@ class TestDatasetMapper:
 
     def test_fixed_path_mappings(self):
         dsm = DatasetMapper('proj_test.my.first.test')
-        assert dsm._data_path == '/projects/test/proj/first/file.txt'
-
+        assert dsm._data_path == '/projects/test/proj/first/test/something.nc'
+        assert dsm.files == [] # because these do not exist when globbed
+ 
         dsm = DatasetMapper('proj_test.my.second.test')
-        assert dsm._data_path == '/projects/test/proj/second/*.txt'
+        assert dsm._data_path == '/projects/test/proj/second/test/data_*.txt'
+        assert dsm.files == [] # because these do not exist when globbed
 
         dsm = DatasetMapper('proj_test.my.unknown')
         assert dsm._data_path == '/projects/test/proj/my/unknown'


### PR DESCRIPTION
This PR adds new functionality for mapping dataset IDs to paths using `fixed_path_mappings` which are supplied as a dictionary in the `roocs.ini` config file. E.g.:

```
[project:proj_test]
base_dir = /projects/test/proj
fixed_path_mappings =
        proj_test.my.first.test:first/test/something.nc
        proj_test.my.second.test:second/test/data_*.txt
```

The DataMapper now identifies and uses these as its method of:
- mapping the dset ID to a file path
- finding data files based on a glob pattern (or exact file/path name)

There should be no change to the default/existing functionality.