### PR TITLE
changed load_test_data to use GitPython

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 black pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
     - name: Lint with flake8
       run: flake8 roocs_utils tests
       if: matrix.python-version == 3.6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,4 @@ twine==1.12.1
 pytest==3.8.2
 pytest-runner==4.2
 pre-commit==2.7.1
+GitPython==3.1.12

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,12 +39,12 @@ def load_test_data():
     This fixture ensures that the required test data repository
     has been cloned to the cache directory within the home directory.
     """
-    branch="master"
+    branch = "master"
     target = os.path.join(MINI_ESGF_CACHE_DIR, branch)
 
     if not os.path.isdir(MINI_ESGF_CACHE_DIR):
         os.makedirs(MINI_ESGF_CACHE_DIR)
-    
+
     if not os.path.isdir(target):
         repo = Repo.clone_from(TEST_DATA_REPO_URL, target)
         repo.git.checkout(branch)
@@ -53,4 +53,3 @@ def load_test_data():
         repo = Repo(target)
         repo.git.checkout(branch)
         repo.remotes[0].pull()
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,15 +39,18 @@ def load_test_data():
     This fixture ensures that the required test data repository
     has been cloned to the cache directory within the home directory.
     """
-    target = os.path.join(MINI_ESGF_CACHE_DIR, "master")
+    branch="master"
+    target = os.path.join(MINI_ESGF_CACHE_DIR, branch)
 
     if not os.path.isdir(MINI_ESGF_CACHE_DIR):
         os.makedirs(MINI_ESGF_CACHE_DIR)
     
     if not os.path.isdir(target):
-        Repo.clone_from(TEST_DATA_REPO_URL, target)
+        repo = Repo.clone_from(TEST_DATA_REPO_URL, target)
+        repo.git.checkout(branch)
 
     if not os.environ.get('ROOCS_AUTO_UPDATE_TEST_DATA', True) == 'FALSE':
         repo = Repo(target)
+        repo.git.checkout(branch)
         repo.remotes[0].pull()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from git import Repo
 from pathlib import Path
 
 import pytest
@@ -38,14 +39,15 @@ def load_test_data():
     This fixture ensures that the required test data repository
     has been cloned to the cache directory within the home directory.
     """
-    tmp_repo = "/tmp/.mini-esgf-data"
-    test_data_dir = os.path.join(tmp_repo, "test_data")
     target = os.path.join(MINI_ESGF_CACHE_DIR, "master")
 
+    if not os.path.isdir(MINI_ESGF_CACHE_DIR):
+        os.makedirs(MINI_ESGF_CACHE_DIR)
+    
     if not os.path.isdir(target):
+        Repo.clone_from(TEST_DATA_REPO_URL, target)
 
-        os.makedirs(target)
-        os.system(f"git clone {TEST_DATA_REPO_URL} {tmp_repo}")
+    if not os.environ.get('ROOCS_AUTO_UPDATE_TEST_DATA', True) == 'FALSE':
+        repo = Repo(target)
+        repo.remotes[0].pull()
 
-        shutil.move(test_data_dir, target)
-        shutil.rmtree(tmp_repo)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def load_test_data():
         repo = Repo.clone_from(TEST_DATA_REPO_URL, target)
         repo.git.checkout(branch)
 
-    if not os.environ.get('ROOCS_AUTO_UPDATE_TEST_DATA', True) == 'FALSE':
+    if not os.environ.get("ROOCS_AUTO_UPDATE_TEST_DATA", True) == "FALSE":
         repo = Repo(target)
         repo.git.checkout(branch)
         repo.remotes[0].pull()


### PR DESCRIPTION
Now cloning the `mini-esgf-data` repository with GitPython instead of making an os command call. This makes pulling the repo, to keep it up to date, simpler.