### PR TITLE
Fix pandas import

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Version History
 ===============
 
+v0.2.1 (2021-02-19)
+-------------------
+
+Bug Fixes
+^^^^^^^^^
+
+* clean up imports ... remove pandas dependency.
+
 v0.2.0 (2021-02-18)
 -------------------
 

--- a/roocs_utils/inventory/batch.py
+++ b/roocs_utils/inventory/batch.py
@@ -1,7 +1,5 @@
 import os
 
-import pandas as pd
-
 from roocs_utils import CONFIG
 from roocs_utils.inventory import logging
 from roocs_utils.inventory.utils import create_dir


### PR DESCRIPTION
This PR removes the unused pandas import. 

See: https://github.com/conda-forge/roocs-utils-feedstock/pull/6

When merge I will make a 0.2.1 release.