### PR TITLE
add AnyCalendarDateTime to time_inputs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,12 +1,16 @@
 Version History
 ===============
 
+v0.3.0 (Unreleased)
+-------------------
+New Features
+^^^^^^^^^^^^
+* Added ``AnyCalendarDateTime`` and ``str_to_AnyCalendarDateTime`` to ``utils.time_utils`` to aid in handling date strings that may not exist in all calendar types.
+
 v0.2.1 (2021-02-19)
 -------------------
-
 Bug Fixes
 ^^^^^^^^^
-
 * clean up imports ... remove pandas dependency.
 
 v0.2.0 (2021-02-18)

--- a/roocs_utils/utils/time_utils.py
+++ b/roocs_utils/utils/time_utils.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 
 
@@ -12,3 +14,94 @@ def to_isoformat(tm):
         return str(tm).split(".")[0]
     else:
         return tm.isoformat()
+
+
+class AnyCalendarDateTime:
+    """
+    A class to represent a datetime that could be of any calendar.
+
+    Has the ability to add and subtract a day from the input based on MAX_DAY, MIN_DAY, MAX_MONTH and MIN_MONTH
+    """
+
+    # MAX_DAY: the maximum number of days in any month in any of the calendars supported by cftime
+    MAX_DAY = 31
+    MIN_DAY = 1
+    MAX_MONTH = 12
+    MIN_MONTH = 1
+
+    def __init__(self, year, month, day, hour, minute, second):
+        self.year = year
+        self.month = month
+        self.day = day
+        self.hour = hour
+        self.minute = minute
+        self.second = second
+
+    def __repr__(self):
+        return self.value
+
+    @property
+    def value(self):
+        return (
+            f"{self.year}-{self.month:02d}-{self.day:02d}"
+            f"T{self.hour:02d}:{self.minute:02d}:{self.second:02d}"
+        )
+
+    def add_day(self):
+        """
+        Add a day to the input datetime.
+        """
+        self.day += 1
+
+        if self.day > self.MAX_DAY:
+            self.month += 1
+            self.day = 1
+
+        if self.month > self.MAX_MONTH:
+            self.year += 1
+            self.month = self.MIN_MONTH
+
+    def sub_day(self, n=1):
+        """
+        Subtract a day to the input datetime.
+        """
+        self.day -= 1
+
+        if self.day < self.MIN_DAY:
+            self.month -= 1
+            self.day = self.MAX_DAY
+
+        if self.month < self.MIN_MONTH:
+            self.year -= 1
+            self.month = self.MAX_MONTH
+
+
+def str_to_AnyCalendarDateTime(dt):
+    """
+    Takes a string representing date/time and returns a DateTimeAnyTime object.
+    String formats should start with Year and go through to Second, but you
+    can miss out anything from month onwards.
+
+    :param dt: string representing a date/time [string]
+    :return: AnyCalendarDateTime object
+    """
+    if len(dt) < 1:
+        raise Exception(
+            "Must provide at least the year as argument to create date time."
+        )
+
+    # Start with most common pattern
+    regex = re.compile(r"^(\d+)-(\d+)-(\d+)[T ](\d+):(\d+):(\d+)$")
+    match = regex.match(dt)
+
+    if match:
+        items = match.groups()
+    else:
+        # Try a more complex split and build of the time string
+        defaults = [-1, 1, 1, 0, 0, 0]
+        components = re.split("[- T:]", dt)
+
+        # Build a list of time components
+        items = components + defaults[len(components) :]
+
+    return AnyCalendarDateTime(*[int(i) for i in items])

--- a/roocs_utils/utils/time_utils.py
+++ b/roocs_utils/utils/time_utils.py
@@ -23,19 +23,37 @@ class AnyCalendarDateTime:
     Has the ability to add and subtract a day from the input based on MAX_DAY, MIN_DAY, MAX_MONTH and MIN_MONTH
     """
 
-    # MAX_DAY: the maximum number of days in any month in any of the calendars supported by cftime
-    MAX_DAY = 31
-    MIN_DAY = 1
-    MAX_MONTH = 12
-    MIN_MONTH = 1
+    MONTH_RANGE = range(1, 13)
+    # 31 is the maximum number of days in any month in any of the calendars supported by cftime
+    DAY_RANGE = range(1, 32)
+    HOUR_RANGE = range(0, 24)
+    MINUTE_RANGE = range(0, 60)
+    SECOND_RANGE = range(0, 60)
 
     def __init__(self, year, month, day, hour, minute, second):
+
         self.year = year
+
         self.month = month
+        self.validate_input(self.month, "month", self.MONTH_RANGE)
+
         self.day = day
+        self.validate_input(self.day, "day", self.DAY_RANGE)
+
         self.hour = hour
+        self.validate_input(self.hour, "hour", self.HOUR_RANGE)
+
         self.minute = minute
+        self.validate_input(self.minute, "minute", self.MINUTE_RANGE)
+
         self.second = second
+        self.validate_input(self.second, "second", self.SECOND_RANGE)
+
+    def validate_input(self, input, name, range):
+        if input not in range:
+            raise ValueError(
+                f"Invalid input {input} for {name}. Expected value between {range[0]} and {range[-1]}."
+            )
 
     def __repr__(self):
         return self.value
@@ -53,13 +71,13 @@ class AnyCalendarDateTime:
         """
         self.day += 1
 
-        if self.day > self.MAX_DAY:
+        if self.day > self.DAY_RANGE[-1]:
             self.month += 1
             self.day = 1
 
-        if self.month > self.MAX_MONTH:
+        if self.month > self.MONTH_RANGE[-1]:
             self.year += 1
-            self.month = self.MIN_MONTH
+            self.month = self.MONTH_RANGE[0]
 
     def sub_day(self, n=1):
         """
@@ -67,13 +85,13 @@ class AnyCalendarDateTime:
         """
         self.day -= 1
 
-        if self.day < self.MIN_DAY:
+        if self.day < self.DAY_RANGE[0]:
             self.month -= 1
-            self.day = self.MAX_DAY
+            self.day = self.DAY_RANGE[-1]
 
-        if self.month < self.MIN_MONTH:
+        if self.month < self.MONTH_RANGE[0]:
             self.year -= 1
-            self.month = self.MAX_MONTH
+            self.month = self.MONTH_RANGE[-1]
 
 
 def str_to_AnyCalendarDateTime(dt):

--- a/tests/test_utils/test_time_utils.py
+++ b/tests/test_utils/test_time_utils.py
@@ -1,0 +1,48 @@
+from roocs_utils.utils.time_utils import AnyCalendarDateTime
+from roocs_utils.utils.time_utils import str_to_AnyCalendarDateTime
+
+
+def test_AnyCalendarDateTime():
+    d = AnyCalendarDateTime(1997, 4, 9, 0, 0, 0)
+    assert d.value == "1997-04-09T00:00:00"
+
+
+def test_str_to_AnyCalendarDateTime():
+    d = str_to_AnyCalendarDateTime("1999-01-31")
+    d.sub_day()
+    assert d.value.startswith("1999-01-30")
+
+    d.add_day()
+    d.add_day()
+    assert d.value.startswith("1999-02-01")
+
+    d = str_to_AnyCalendarDateTime("1999-01-33")
+    d.sub_day()
+    d.sub_day()
+    assert d.value.startswith("1999-01-31")
+
+    d = str_to_AnyCalendarDateTime("1999-01-01T12:13:14")
+    d.sub_day()
+    assert d.value == "1998-12-31T12:13:14"
+
+
+def test_irregular_datetimes():
+    # looks like no year
+    d = str_to_AnyCalendarDateTime("01-02")
+    #  first value is taken as the year
+    assert d.value == "1-02-01T00:00:00"
+
+    # month is 00
+    d = str_to_AnyCalendarDateTime("1999-00-33")
+    assert d.value == "1999-00-33T00:00:00"
+
+    d.add_day()
+    assert d.value == "1999-01-01T00:00:00"
+
+    # month is 00
+    d = str_to_AnyCalendarDateTime("1999-00-33")
+    assert d.value == "1999-00-33T00:00:00"
+
+    d.sub_day()
+    d.sub_day()
+    assert d.value == "1998-12-31T00:00:00"

--- a/tests/test_utils/test_time_utils.py
+++ b/tests/test_utils/test_time_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from roocs_utils.utils.time_utils import AnyCalendarDateTime
 from roocs_utils.utils.time_utils import str_to_AnyCalendarDateTime
 
@@ -16,10 +18,9 @@ def test_str_to_AnyCalendarDateTime():
     d.add_day()
     assert d.value.startswith("1999-02-01")
 
-    d = str_to_AnyCalendarDateTime("1999-01-33")
+    d = str_to_AnyCalendarDateTime("1999-02-31")
     d.sub_day()
-    d.sub_day()
-    assert d.value.startswith("1999-01-31")
+    assert d.value.startswith("1999-02-30")
 
     d = str_to_AnyCalendarDateTime("1999-01-01T12:13:14")
     d.sub_day()
@@ -33,16 +34,22 @@ def test_irregular_datetimes():
     assert d.value == "1-02-01T00:00:00"
 
     # month is 00
-    d = str_to_AnyCalendarDateTime("1999-00-33")
-    assert d.value == "1999-00-33T00:00:00"
+    with pytest.raises(ValueError) as exc:
+        str_to_AnyCalendarDateTime("1999-00-33")
+    assert (
+        str(exc.value) == "Invalid input 0 for month. Expected value between 1 and 12."
+    )
 
-    d.add_day()
-    assert d.value == "1999-01-01T00:00:00"
+    # month is 13
+    with pytest.raises(ValueError) as exc:
+        str_to_AnyCalendarDateTime("1999-13-22")
+    assert (
+        str(exc.value) == "Invalid input 13 for month. Expected value between 1 and 12."
+    )
 
-    # month is 00
-    d = str_to_AnyCalendarDateTime("1999-00-33")
-    assert d.value == "1999-00-33T00:00:00"
-
-    d.sub_day()
-    d.sub_day()
-    assert d.value == "1998-12-31T00:00:00"
+    # hour is 27
+    with pytest.raises(ValueError) as exc:
+        str_to_AnyCalendarDateTime("1999-01-22T27:00:00")
+    assert (
+        str(exc.value) == "Invalid input 27 for hour. Expected value between 0 and 23."
+    )


### PR DESCRIPTION
Add `AnyCalendarDateTime` components as discussed in https://github.com/roocs/clisops/issues/151. The maximum day for all calendars is 31.

`str_to_AnyCalendarDateTime` will take eg. month = 0 without any complaints (see tests), is that something we would want to flag up? Or is it ok for these purposes because the point is the date might not be sensible?

Once this is in `roocs-utils`, I will re-open https://github.com/roocs/clisops/pull/153
