### PR TITLE
get base dir when project provided

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@ Version History
 
 v0.5.0 (Unreleased)
 -------------------
+Bug Fixes
+^^^^^^^^^
+* When a project was provided to ``roocs_utils.project_utils.DatasetMapper``, getting the base directory would be skipped, causing an error. This has been resolved.
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 * Intake catalog maker removed, now in it's own package: `roocs/catalog-maker <https://github.com/roocs/catalog-maker>`_

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -96,6 +96,10 @@ class DatasetMapper:
                         f"The project could not be identified and force was set to false"
                     )
 
+        # get base_dir in the case where project has been supplied
+        if not self._base_dir and self._project:
+            self._base_dir = get_project_base_dir(self._project)
+
         # if a file, group of files or directory to files - find files
         if dset.startswith("/") or dset.endswith(".nc"):
 


### PR DESCRIPTION
I spotted this case that wasn't covered in DatasetMapper - if the project is provided it would skip the part when it gets the base directory - causing an error. 

This covers that case.
