### PR TITLE
Added support for ".nc.gz" files in DatasetMapper

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ v0.5.0 (Unreleased)
 Bug Fixes
 ^^^^^^^^^
 * When a project was provided to ``roocs_utils.project_utils.DatasetMapper``, getting the base directory would be skipped, causing an error. This has been resolved.
+* ``roocs_utils.project_utils.DatasetMapper`` can now accept `fixed_path_mappings` that include ".gz" (gzip) files. This is allowed because `Xarray` can read gzipped `netCDF` files.
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -25,6 +25,8 @@ class DatasetMapper:
     When force=True, if the project can not be identified, any attempt to use the base_dir of a project
     to resolve the data path will be ignored. Any of data_path, ds_id and files that can be set, will be set.
     """
+    SUPPORTED_EXTENSIONS = (".nc", ".gz")
+
 
     def __init__(self, dset, project=None, force=False):
 
@@ -108,8 +110,8 @@ class DatasetMapper:
                 self._files = self.dset.file_paths
                 self._data_path = self.dset.dirpath
 
-            if dset.endswith(".nc"):
-                if dset.endswith("*.nc"):
+            if os.path.splitext(dset)[-1] in self.SUPPORTED_EXTENSIONS:
+                if "*" in dset:
                     self._files = sorted(glob.glob(dset))
                 else:
                     self._files.append(dset)

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -25,6 +25,7 @@ class DatasetMapper:
     When force=True, if the project can not be identified, any attempt to use the base_dir of a project
     to resolve the data path will be ignored. Any of data_path, ds_id and files that can be set, will be set.
     """
+
     SUPPORTED_EXTENSIONS = (".nc", ".gz")
 
     def __init__(self, dset, project=None, force=False):

--- a/roocs_utils/project_utils.py
+++ b/roocs_utils/project_utils.py
@@ -27,7 +27,6 @@ class DatasetMapper:
     """
     SUPPORTED_EXTENSIONS = (".nc", ".gz")
 
-
     def __init__(self, dset, project=None, force=False):
 
         self._project = project

--- a/roocs_utils/xarray_utils/xarray_utils.py
+++ b/roocs_utils/xarray_utils/xarray_utils.py
@@ -21,10 +21,14 @@ def open_xr_dataset(dset, **kwargs):
     Any list will be interpreted as list of files
     """
 
-    # DatasetMapper doesn't handle lists
-    if not isinstance(dset, list):
+    # Force the value of dset to be a list if not a list or tuple
+    if type(dset) not in (list, tuple):
         # use force=True to allow all file paths to pass through DatasetMapper
         dset = dset_to_filepaths(dset, force=True)
+
+    # If an empty sequence, then raise an Exception
+    if len(dset) == 0:
+        raise Exception("No files found to open with xarray.")
 
     # if a list we want a multi-file dataset
     if len(dset) > 1:


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR is not related to an issue
- [x] All tests run - change is tiny
- [x] Documentation remains unchanged
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->

Tiny change, adding support to be able to read/handle gzipped `netCDF` files. `Xarray` will automatically `gunzip` the files in memory before trying to read them. Some `netCDF` data at CEDA is gzipped so this is very useful.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->

No

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->

See details of how `xarray` can read gzipped data here:

http://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html#xarray-open-dataset