### PR TITLE
Change Parameter capabilities to allow new subsetting options

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,14 @@ Bug Fixes
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 * Intake catalog maker removed, now in it's own package: `roocs/catalog-maker <https://github.com/roocs/catalog-maker>`_
+* Change to input parameter classes::
+  * Added: ``roocs_utils.parameter.time_components_parameter.TimeComponentsParameter``
+  * Modified input types required for classes::
+    * ``roocs_utils.parameter.time_parameter.TimeParameter``
+    * ``roocs_utils.parameter.level_parameter.LevelParameter``
+  * They both now require their inputs to be one of::
+    * ``roocs_utils.parameter.param_utils.Interval`` - to specify a range/interval
+    * ``roocs_utils.parameter.param_utils.Series`` - to specify a series of values
 
 New Features
 ^^^^^^^^^^^^

--- a/roocs_utils/parameter/area_parameter.py
+++ b/roocs_utils/parameter/area_parameter.py
@@ -24,7 +24,6 @@ class AreaParameter(_BaseParameter):
 
     def _parse(self):
         if isinstance(self.input, type(None)) or self.input == "":
-            self.type = "none"
             return None
 
         if isinstance(self.input, (str, bytes)):

--- a/roocs_utils/parameter/area_parameter.py
+++ b/roocs_utils/parameter/area_parameter.py
@@ -1,5 +1,8 @@
+from collections.abc import Sequence
+
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.base_parameter import _BaseParameter
+from roocs_utils.parameter.param_utils import area, to_float, parse_sequence
 
 
 class AreaParameter(_BaseParameter):
@@ -17,46 +20,39 @@ class AreaParameter(_BaseParameter):
 
     """
 
-    parse_method = "_parse_sequence"
+    allowed_input_types = [Sequence, str, area, type(None)]
 
-    def _validate(self):
+    def _parse(self):
+        if isinstance(self.input, type(None)) or self.input == "":
+            self.type = "none"
+            return None
 
-        if self._result is not None and len(self._result) != 4:
+        if isinstance(self.input, (str, bytes)):
+            value = parse_sequence(self.input, caller=self.__class__.__name__)
+
+        elif isinstance(self.input, Sequence):
+            value = self.input
+
+        elif isinstance(self.input, area):
+            value = self.input.value
+
+        self.type = "series"
+
+        if value is not None and len(value) != 4:
             raise InvalidParameterValue(
                 f"{self.__class__.__name__} should be of length 4 but is of length "
-                f"{len(self._result)}"
+                f"{len(value)}"
             )
-        self._parse_values()
 
-    def _parse_values(self):
-        if self._result is None:
-            return self._result
-
-        area = []
-        for value in self._result:
-            if isinstance(value, str):
-                if not value.replace(".", "", 1).strip("-").isdigit():
-                    raise InvalidParameterValue("Area values must be a number")
-            else:
-                if not (isinstance(value, float) or isinstance(value, int)):
-                    raise InvalidParameterValue("Area values must be a number")
-
-            area.append(float(value))
-
-        return tuple(area)
-
-    @property
-    def tuple(self):
-        """Returns a tuple of the area values"""
-        return self._parse_values()
+        return tuple([to_float(i, allow_none=False) for i in value])
 
     def asdict(self):
         """Returns a dictionary of the area values"""
-        if self.tuple is not None:
+        if self.value is not None:
             return {
-                "lon_bnds": (self.tuple[0], self.tuple[2]),
-                "lat_bnds": (self.tuple[1], self.tuple[3]),
+                "lon_bnds": (self.value[0], self.value[2]),
+                "lat_bnds": (self.value[1], self.value[3]),
             }
 
     def __str__(self):
-        return f"Area to subset over:" f"\n {self.tuple}"
+        return f"Area to subset over:" f"\n {self.value}"

--- a/roocs_utils/parameter/base_parameter.py
+++ b/roocs_utils/parameter/base_parameter.py
@@ -17,7 +17,7 @@ class _BaseParameter(object):
     def __init__(self, input):
         self.input = self.raw = input
 
-        # If the input is already an instance of this class, call its parse method 
+        # If the input is already an instance of this class, call its parse method
         if isinstance(self.input, self.__class__):
             self.value = self.input._parse()
         else:
@@ -25,11 +25,13 @@ class _BaseParameter(object):
             self.value = self._parse()
 
     def _check_input_type(self):
-        if not self.allowed_input_types: 
+        if not self.allowed_input_types:
             return
         if not isinstance(self.input, tuple(self.allowed_input_types)):
-            raise InvalidParameterValue(f"Input type of {type(self.input)} not allowed. "
-                            f"Must be one of: {self.allowed_input_types}")
+            raise InvalidParameterValue(
+                f"Input type of {type(self.input)} not allowed. "
+                f"Must be one of: {self.allowed_input_types}"
+            )
 
     def _parse(self):
         raise NotImplementedError
@@ -52,6 +54,7 @@ class _BaseIntervalOrSeriesParameter(_BaseParameter):
         type: "interval" --> value: (start, end)
         type: "series"   --> value: [item1, item2, ..., item_n]
     """
+
     allowed_input_types = [interval, series, type(None)]
 
     def _parse(self):

--- a/roocs_utils/parameter/base_parameter.py
+++ b/roocs_utils/parameter/base_parameter.py
@@ -61,7 +61,7 @@ class _BaseIntervalOrSeriesParameter(_BaseParameter):
             return self._parse_as_interval()
         elif isinstance(self.input, series):
             self.type = "series"
-            self._parse_as_series()
+            return self._parse_as_series()
         elif isinstance(self.input, type(None)):
             self.type = "none"
             return None

--- a/roocs_utils/parameter/collection_parameter.py
+++ b/roocs_utils/parameter/collection_parameter.py
@@ -19,6 +19,7 @@ class CollectionParameter(_BaseParameter):
     Validates the input and parses the items.
 
     """
+
     allowed_input_types = [Sequence, str, collection]
 
     def _parse(self):

--- a/roocs_utils/parameter/dimension_parameter.py
+++ b/roocs_utils/parameter/dimension_parameter.py
@@ -18,19 +18,21 @@ class DimensionParameter(_BaseParameter):
 
     """
 
-    parse_method = "_parse_sequence"
+    preparser = _BaseParameter._parse_sequence
 
     def _validate(self):
 
         self._parse_dims()
 
     def _parse_dims(self):
+        
         if self._result is None:
             return self._result
 
         for value in self._result:
             if not (isinstance(value, str)):
                 raise InvalidParameterValue(f"Each dimension must be a string.")
+
             if value not in known_coord_types:
                 raise InvalidParameterValue(
                     f"Dimensions for averaging must be one of {known_coord_types}"

--- a/roocs_utils/parameter/level_parameter.py
+++ b/roocs_utils/parameter/level_parameter.py
@@ -38,13 +38,19 @@ class LevelParameter(_BaseIntervalOrSeriesParameter):
 
     def asdict(self):
         """Returns a dictionary of the level values"""
-        value = self._value_as_tuple()
-        return {"first_level": value[0], "last_level": value[1]}
+        if self.type in ("interval", "none"):
+            value = self._value_as_tuple()
+            return {"first_level": value[0], "last_level": value[1]}
+        elif self.type == "series":
+            return {"level_values": self.value}
 
     def __str__(self):
-        value = self._value_as_tuple()
-        return (
-            f"Level range to subset over"
-            f"\n first_level: {value[0]}"
-            f"\n last_level: {value[1]}"
-        )
+        if self.type in ("interval", "none"):
+            value = self._value_as_tuple()
+            return (
+                f"Level range to subset over"
+                f"\n first_level: {value[0]}"
+                f"\n last_level: {value[1]}"
+            )
+        else:
+            return f"Level values to select: {self.value}"

--- a/roocs_utils/parameter/level_parameter.py
+++ b/roocs_utils/parameter/level_parameter.py
@@ -1,10 +1,12 @@
 import numbers
 
 from roocs_utils.exceptions import InvalidParameterValue
-from roocs_utils.parameter.base_parameter import _BaseParameter
+from roocs_utils.parameter.base_parameter import _BaseIntervalOrSeriesParameter
+from roocs_utils.parameter.param_utils import (parse_range, parse_sequence,
+                            to_float, interval, series)
 
 
-class LevelParameter(_BaseParameter):
+class LevelParameter(_BaseIntervalOrSeriesParameter):
     """
     Class for level parameter used in subsetting operation.
 
@@ -23,43 +25,26 @@ class LevelParameter(_BaseParameter):
 
     """
 
-    parse_method = "_parse_range"
+    def _parse_as_interval(self):
+        value = tuple([to_float(i) for i in self.input.value])
 
-    def _validate(self):
-        self._parse_levels()
+        if set(value) == {None}:
+            value = None
 
-    def _parse_levels(self):
-        result = [None, None]
+        return value
 
-        for count, value in enumerate(self._result):
-            if value is None:
-                continue
-
-            if isinstance(value, str):
-                try:
-                    value = float(value)
-                except Exception:
-                    raise InvalidParameterValue("Level values must be a number")
-
-            if not isinstance(value, numbers.Number):
-                raise InvalidParameterValue("Level values must be a number")
-
-            result[count] = value
-
-        return tuple(result)
-
-    @property
-    def tuple(self):
-        """Returns a tuple of the level values"""
-        return self._parse_levels()
+    def _parse_as_series(self):
+        return [to_float(i) for i in self.input.value if i is not None]
 
     def asdict(self):
         """Returns a dictionary of the level values"""
-        return {"first_level": self.tuple[0], "last_level": self.tuple[1]}
+        value = self._value_as_tuple()
+        return {"first_level": value[0], "last_level": value[1]}
 
     def __str__(self):
+        value = self._value_as_tuple()
         return (
             f"Level range to subset over"
-            f"\n first_level: {self.tuple[0]}"
-            f"\n last_level: {self.tuple[1]}"
+            f"\n first_level: {value[0]}"
+            f"\n last_level: {value[1]}"
         )

--- a/roocs_utils/parameter/level_parameter.py
+++ b/roocs_utils/parameter/level_parameter.py
@@ -2,8 +2,13 @@ import numbers
 
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.base_parameter import _BaseIntervalOrSeriesParameter
-from roocs_utils.parameter.param_utils import (parse_range, parse_sequence,
-                            to_float, interval, series)
+from roocs_utils.parameter.param_utils import (
+    parse_range,
+    parse_sequence,
+    to_float,
+    interval,
+    series,
+)
 
 
 class LevelParameter(_BaseIntervalOrSeriesParameter):

--- a/roocs_utils/parameter/param_utils.py
+++ b/roocs_utils/parameter/param_utils.py
@@ -89,6 +89,9 @@ class Series:
     as a list.
     """
     def __init__(self, *data):
+        if len(data) == 1:
+            data = data[0]
+
         self.value = parse_sequence(data, caller=self.__class__.__name__)
    
 
@@ -158,5 +161,5 @@ def to_float(i, allow_none=True):
 time_series = level_series = series = Series
 time_interval = level_interval = interval = Interval
 time_components = TimeComponents
-area = Series
+area = collection = dimensions = Series
 collection = Series

--- a/roocs_utils/parameter/param_utils.py
+++ b/roocs_utils/parameter/param_utils.py
@@ -1,0 +1,162 @@
+from collections.abc import Sequence
+from dateutil import parser as date_parser
+import calendar
+
+from roocs_utils.exceptions import InvalidParameterValue
+from roocs_utils.exceptions import MissingParameterValue
+from roocs_utils.utils.file_utils import FileMapper
+
+
+# Global variables that are generally useful
+month_map = {name.lower(): num for num, name in enumerate(calendar.month_abbr) if num}
+time_comp_limits = {
+    "year": None, 
+    "month": (1, 12),
+    "day": (1, 40),     # allowing for strange calendars
+    "hour": (0, 23),
+    "minute": (0, 59),
+    "second": (0, 59)
+}
+
+
+# A set of simple parser functions
+def parse_range(x, caller):
+    if isinstance(x, Sequence) and len(x) == 1:
+        x = x[0]
+
+    if x in ("/", None, ""):
+        start = None
+        end = None
+
+    elif isinstance(x, str):
+        if "/" not in x:
+            raise InvalidParameterValue(
+                f"{caller} should be passed in as a range separated by /"
+            )
+
+        # empty string either side of '/' is converted to None
+        start, end = [i.strip() or None for i in x.split("/")]
+
+    elif isinstance(x, Sequence):
+        if len(x) != 2:
+            raise InvalidParameterValue(
+                f"{caller} should be a range. Expected 2 values, "
+                f"received {len(x)}"
+            )
+
+        start, end = x
+
+    else:
+        raise InvalidParameterValue(
+            f"{caller} is not in an accepted format"
+        )
+    return start, end
+
+
+def parse_sequence(x, caller):
+
+    if x in (None, ""):
+        sequence = None
+
+    # check str or bytes
+    elif isinstance(x, (str, bytes)):
+        sequence = [i.strip() for i in x.strip().split(",")]
+
+    elif isinstance(x, FileMapper):
+        sequence = [x]
+
+    elif isinstance(x, Sequence):
+        sequence = x
+
+    else:
+        raise InvalidParameterValue(
+            f"{caller} is not in an accepted format"
+        )
+
+    return sequence
+
+
+def parse_datetime(dt, default=None):
+    """Parses string to datetime and returns isoformat string for it.
+    If `default` is set, use that in case `dt` is None."""
+    return date_parser.parse(dt, default=default).isoformat()
+
+
+class Series:
+    """
+    A simple class for handling a series selection, created by
+    any sequence as input. It has a `value` that holds the sequence
+    as a list.
+    """
+    def __init__(self, *data):
+        self.value = parse_sequence(data, caller=self.__class__.__name__)
+   
+
+class Interval:
+    """
+    A simple class for handling an interval of any type.
+    It holds a `start` and `end` but does not try to resolve
+    the range, it is just a container to be used by other tools.
+    The contents can be of any type, such as datetimes, strings etc.
+    """
+
+    def __init__(self, *data):
+        self.value = parse_range(data, self.__class__.__name__)
+
+
+class TimeComponents:
+    """
+    A simple class for parsing and representing a set of time components.
+    The components are stored in a dictionary of {time_comp: values}, such
+    as: 
+        {"year": [2000, 2001], "month": [1, 2, 3]}
+
+    Note that you can provide month strings as strings or numbers, e.g.:
+        "feb", "Feb", "February", 2
+    """
+
+    def __init__(self, year=None, month=None, day=None, hour=None,
+                 minute=None, second=None):
+        comps = ("year", "month", "day", "hour", "minute", "second")
+        
+        self.value = {}
+        for comp in comps:
+            if comp in locals():
+                self.value[comp] = self._parse(locals()[comp], comp)
+
+    def _parse_component(self, value, time_comp):
+        limits = time_comp_limits[time_comp]
+
+        if not isinstance(value, Sequence):
+            value = [value]
+
+        def _month_to_int(month):
+            if isinstance(month, str):
+                return month_map.get(month.lower()[:3])
+            return month
+
+        if time_comp == "month":
+            value = [_month_to_int(month) for month in value]
+        
+        if limits:
+            mn, mx = min(value), max(value)
+            if mn < limits[0] or mx > limits[1]:
+                raise ValueError(f"Some time components are out of range for {time_comp}: "
+                                f"({mn}, {mx})")
+
+        return value
+
+def to_float(i, allow_none=True):
+    try:
+        if allow_none and i is None: 
+            return i
+        return float(i)
+    except:
+        raise InvalidParameterValue("Values must be valid numbers")
+
+# Create some aliases for our simple selection types
+time_series = level_series = series = Series
+time_interval = level_interval = interval = Interval
+time_components = TimeComponents
+area = Series
+collection = Series

--- a/roocs_utils/parameter/param_utils.py
+++ b/roocs_utils/parameter/param_utils.py
@@ -9,13 +9,14 @@ from roocs_utils.utils.file_utils import FileMapper
 
 # Global variables that are generally useful
 month_map = {name.lower(): num for num, name in enumerate(calendar.month_abbr) if num}
+
 time_comp_limits = {
-    "year": None, 
+    "year": None,
     "month": (1, 12),
-    "day": (1, 40),     # allowing for strange calendars
+    "day": (1, 40),  # allowing for strange calendars
     "hour": (0, 23),
     "minute": (0, 59),
-    "second": (0, 59)
+    "second": (0, 59),
 }
 
 
@@ -40,16 +41,13 @@ def parse_range(x, caller):
     elif isinstance(x, Sequence):
         if len(x) != 2:
             raise InvalidParameterValue(
-                f"{caller} should be a range. Expected 2 values, "
-                f"received {len(x)}"
+                f"{caller} should be a range. Expected 2 values, " f"received {len(x)}"
             )
 
         start, end = x
 
     else:
-        raise InvalidParameterValue(
-            f"{caller} is not in an accepted format"
-        )
+        raise InvalidParameterValue(f"{caller} is not in an accepted format")
     return start, end
 
 
@@ -69,9 +67,7 @@ def parse_sequence(x, caller):
         sequence = x
 
     else:
-        raise InvalidParameterValue(
-            f"{caller} is not in an accepted format"
-        )
+        raise InvalidParameterValue(f"{caller} is not in an accepted format")
 
     return sequence
 
@@ -88,12 +84,13 @@ class Series:
     any sequence as input. It has a `value` that holds the sequence
     as a list.
     """
+
     def __init__(self, *data):
         if len(data) == 1:
             data = data[0]
 
         self.value = parse_sequence(data, caller=self.__class__.__name__)
-   
+
 
 class Interval:
     """
@@ -111,55 +108,83 @@ class TimeComponents:
     """
     A simple class for parsing and representing a set of time components.
     The components are stored in a dictionary of {time_comp: values}, such
-    as: 
+    as:
         {"year": [2000, 2001], "month": [1, 2, 3]}
 
     Note that you can provide month strings as strings or numbers, e.g.:
         "feb", "Feb", "February", 2
     """
 
-    def __init__(self, year=None, month=None, day=None, hour=None,
-                 minute=None, second=None):
+    def __init__(
+        self, year=None, month=None, day=None, hour=None, minute=None, second=None
+    ):
         comps = ("year", "month", "day", "hour", "minute", "second")
-        
+
         self.value = {}
         for comp in comps:
-            if comp in locals():
-                self.value[comp] = self._parse(locals()[comp], comp)
 
-    def _parse_component(self, value, time_comp):
+            if comp in locals():
+                value = locals()[comp]
+
+                # Only add to dict if defined
+                if value is not None:
+                    self.value[comp] = self._parse_component(comp, value)
+
+    def _parse_component(self, time_comp, value):
         limits = time_comp_limits[time_comp]
+
+        if isinstance(value, str):
+            if "," in value:
+                value = value.split(",")
+            else:
+                value = [value]
 
         if not isinstance(value, Sequence):
             value = [value]
 
         def _month_to_int(month):
             if isinstance(month, str):
-                return month_map.get(month.lower()[:3])
-            return month
+                month = month_map.get(month.lower()[:3], month)
+            return int(month)
 
         if time_comp == "month":
             value = [_month_to_int(month) for month in value]
-        
+        else:
+            value = [int(i) for i in value]
+
         if limits:
             mn, mx = min(value), max(value)
             if mn < limits[0] or mx > limits[1]:
-                raise ValueError(f"Some time components are out of range for {time_comp}: "
-                                f"({mn}, {mx})")
+                raise ValueError(
+                    f"Some time components are out of range for {time_comp}: "
+                    f"({mn}, {mx})"
+                )
 
         return value
 
+
+def string_to_dict(s, splitters=("|", ":", ",")):
+    """Convert a string to a dictionary of dictionaries, based on
+    splitting rules: splitters."""
+    dct = {}
+
+    for tdict in s.strip().split(splitters[0]):
+        key, value = tdict.split(splitters[1])
+        dct[key] = value.split(splitters[2])
+
+    return dct
+
+
 def to_float(i, allow_none=True):
     try:
-        if allow_none and i is None: 
+        if allow_none and i is None:
             return i
         return float(i)
-    except:
+    except Exception:
         raise InvalidParameterValue("Values must be valid numbers")
 
-# Create some aliases for our simple selection types
-time_series = level_series = series = Series
-time_interval = level_interval = interval = Interval
+
+# Create some aliases for creating simple selection types
+series = time_series = level_series = area = collection = dimensions = Series
+interval = time_interval = level_interval = Interval
 time_components = TimeComponents
-area = collection = dimensions = Series
-collection = Series

--- a/roocs_utils/parameter/parameterise.py
+++ b/roocs_utils/parameter/parameterise.py
@@ -4,9 +4,11 @@ from roocs_utils.parameter import area_parameter
 from roocs_utils.parameter import collection_parameter
 from roocs_utils.parameter import level_parameter
 from roocs_utils.parameter import time_parameter
+from roocs_utils.parameter import time_components_parameter
 
 
-def parameterise(collection=None, area=None, level=None, time=None):
+def parameterise(collection=None, area=None, level=None, time=None,
+                 time_components=None):
     """
     Parameterises inputs to instances of parameter classes which allows
     them to be used throughout roocs.
@@ -16,6 +18,7 @@ def parameterise(collection=None, area=None, level=None, time=None):
     :param area: Area input in any supported format.
     :param level: Level input in any supported format.
     :param time: Time input in any supported format.
+    :param time_components: Time Components input in any supported format.
     :return: Parameters as instances of their respective classes.
     """
 
@@ -24,7 +27,10 @@ def parameterise(collection=None, area=None, level=None, time=None):
         collection = collection_parameter.CollectionParameter(collection)
 
     area = area_parameter.AreaParameter(area)
-    time = time_parameter.TimeParameter(time)
     level = level_parameter.LevelParameter(level)
+    time = time_parameter.TimeParameter(time)
+    time_components = time_components_parameter.TimeComponentsParameter(
+                          time_components)
 
     return locals()
+

--- a/roocs_utils/parameter/parameterise.py
+++ b/roocs_utils/parameter/parameterise.py
@@ -7,8 +7,9 @@ from roocs_utils.parameter import time_parameter
 from roocs_utils.parameter import time_components_parameter
 
 
-def parameterise(collection=None, area=None, level=None, time=None,
-                 time_components=None):
+def parameterise(
+    collection=None, area=None, level=None, time=None, time_components=None
+):
     """
     Parameterises inputs to instances of parameter classes which allows
     them to be used throughout roocs.
@@ -29,8 +30,6 @@ def parameterise(collection=None, area=None, level=None, time=None,
     area = area_parameter.AreaParameter(area)
     level = level_parameter.LevelParameter(level)
     time = time_parameter.TimeParameter(time)
-    time_components = time_components_parameter.TimeComponentsParameter(
-                          time_components)
+    time_components = time_components_parameter.TimeComponentsParameter(time_components)
 
     return locals()
-

--- a/roocs_utils/parameter/time_components_parameter.py
+++ b/roocs_utils/parameter/time_components_parameter.py
@@ -1,66 +1,53 @@
-import datetime
-
-from dateutil import parser as date_parser
-
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.base_parameter import _BaseParameter
+from roocs_utils.parameter.param_utils import time_components, string_to_dict
 
 
 class TimeComponentsParameter(_BaseParameter):
     """
     Class for time components parameter used in subsetting operation.
 
-*************
+    The Time Components are any, or none of:
+      - year: [list of years]
+      - month: [list of months]
+      - day: [list of days]
+      - hour: [list of hours]
+      - minute: [list of minutes]
+      - second: [list of seconds]
 
+    `month` is special: you can use either strings or values:
+       "feb", "mar" == 2, 3 == "02,03"
 
-NEED TO DOCUMENT
-
-
-****
-
-
-    Validates the times input and parses the values into isoformat.
-
+    Validates the times input and parses the them into a dictionary.
     """
 
- #   parse_method = "_parse_range"
+    allowed_input_types = [dict, str, time_components, type(None)]
 
-    def _validate(self):
+    def _parse(self):
         try:
-            self._parse_times()
-
-        except (date_parser._parser.ParserError, TypeError):
-            raise InvalidParameterValue("Unable to parse the time values entered")
-
-    def _parse_times(self):
-        # should this default to the start and end time of the data?
-        start, end = self._result
-
-        if start is not None:
-            start = date_parser.parse(
-                start, default=datetime.datetime(datetime.MINYEAR, 1, 1)
-            ).isoformat()
-        if end is not None:
-            end = date_parser.parse(
-                end, default=datetime.datetime(datetime.MAXYEAR, 12, 30)
-            ).isoformat()
-
-        return start, end
-
-    @property
-    def tuple(self):
-        """Returns a tuple of the time values"""
-        if self._parse_times() is not (None, None):
-            return self._parse_times()
+            if self.input in (None, ""):
+                return None
+            elif isinstance(self.input, time_components):
+                return self.input.value
+            elif isinstance(self.input, str):
+                time_comp_dict = string_to_dict(self.input, splitters=("|", ":", ","))
+                return time_components(**time_comp_dict).value
+            else:  # Must be a dict to get here
+                return time_components(**self.input).value
+        except Exception:
+            raise InvalidParameterValue(
+                f"Cannot create TimeComponentsParameter " f"from: {self.input}"
+            )
 
     def asdict(self):
-        """Returns a dictionary of the time values"""
-        if self.tuple is not None:
-            return {"start_time": self.tuple[0], "end_time": self.tuple[1]}
+        # Just return the value, either a dict or None
+        return self.value
 
     def __str__(self):
-        return (
-            f"Time period to subset over"
-            f"\n start time: {self.tuple[0]}"
-            f"\n end time: {self.tuple[1]}"
-        )
+        if self.value is None:
+            return "No time components specified"
+
+        resp = "Time components to select:"
+        for key, value in self.value.items():
+            resp += f"\n    {key} => {value}"
+        return resp

--- a/roocs_utils/parameter/time_components_parameter.py
+++ b/roocs_utils/parameter/time_components_parameter.py
@@ -1,0 +1,66 @@
+import datetime
+
+from dateutil import parser as date_parser
+
+from roocs_utils.exceptions import InvalidParameterValue
+from roocs_utils.parameter.base_parameter import _BaseParameter
+
+
+class TimeComponentsParameter(_BaseParameter):
+    """
+    Class for time components parameter used in subsetting operation.
+
+*************
+
+
+NEED TO DOCUMENT
+
+
+****
+
+
+    Validates the times input and parses the values into isoformat.
+
+    """
+
+ #   parse_method = "_parse_range"
+
+    def _validate(self):
+        try:
+            self._parse_times()
+
+        except (date_parser._parser.ParserError, TypeError):
+            raise InvalidParameterValue("Unable to parse the time values entered")
+
+    def _parse_times(self):
+        # should this default to the start and end time of the data?
+        start, end = self._result
+
+        if start is not None:
+            start = date_parser.parse(
+                start, default=datetime.datetime(datetime.MINYEAR, 1, 1)
+            ).isoformat()
+        if end is not None:
+            end = date_parser.parse(
+                end, default=datetime.datetime(datetime.MAXYEAR, 12, 30)
+            ).isoformat()
+
+        return start, end
+
+    @property
+    def tuple(self):
+        """Returns a tuple of the time values"""
+        if self._parse_times() is not (None, None):
+            return self._parse_times()
+
+    def asdict(self):
+        """Returns a dictionary of the time values"""
+        if self.tuple is not None:
+            return {"start_time": self.tuple[0], "end_time": self.tuple[1]}
+
+    def __str__(self):
+        return (
+            f"Time period to subset over"
+            f"\n start time: {self.tuple[0]}"
+            f"\n end time: {self.tuple[1]}"
+        )

--- a/roocs_utils/parameter/time_parameter.py
+++ b/roocs_utils/parameter/time_parameter.py
@@ -54,14 +54,19 @@ class TimeParameter(_BaseIntervalOrSeriesParameter):
 
     def asdict(self):
         """Returns a dictionary of the time values"""
-        value = self._value_as_tuple()
-        return {"start_time": value[0], "end_time": value[1]}
+        if self.type in ("interval", "none"):
+            value = self._value_as_tuple()
+            return {"start_time": value[0], "end_time": value[1]}
+        elif self.type == "series":
+            return {"time_values": self.value}
 
     def __str__(self):
-        value = self._value_as_tuple()
-        return (
-            f"Time period to subset over"
-            f"\n start time: {value[0]}"
-            f"\n end time: {value[1]}"
-        )
-
+        if self.type in ("interval", "none"):
+            value = self._value_as_tuple()
+            return (
+                f"Time period to subset over"
+                f"\n start time: {value[0]}"
+                f"\n end time: {value[1]}"
+            )
+        else:
+            return f"Time values to select: {self.value}"

--- a/roocs_utils/parameter/time_parameter.py
+++ b/roocs_utils/parameter/time_parameter.py
@@ -2,8 +2,13 @@ import datetime
 
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.base_parameter import _BaseIntervalOrSeriesParameter
-from roocs_utils.parameter.param_utils import (parse_range, parse_sequence,
-                            parse_datetime, interval, series)
+from roocs_utils.parameter.param_utils import (
+    parse_range,
+    parse_sequence,
+    parse_datetime,
+    interval,
+    series,
+)
 
 
 class TimeParameter(_BaseIntervalOrSeriesParameter):
@@ -29,11 +34,15 @@ class TimeParameter(_BaseIntervalOrSeriesParameter):
 
         try:
             if start is not None:
-                start = parse_datetime(start, default=datetime.datetime(datetime.MINYEAR, 1, 1))
+                start = parse_datetime(
+                    start, default=datetime.datetime(datetime.MINYEAR, 1, 1)
+                )
             if end is not None:
-                end = parse_datetime(end, default=datetime.datetime(datetime.MAXYEAR, 12, 30))
+                end = parse_datetime(
+                    end, default=datetime.datetime(datetime.MAXYEAR, 12, 30)
+                )
 
-        except:
+        except Exception:
             raise InvalidParameterValue("Unable to parse the time values entered")
 
         # Set as None if no start or end, otherwise set as tuple
@@ -47,7 +56,7 @@ class TimeParameter(_BaseIntervalOrSeriesParameter):
     def _parse_as_series(self):
         try:
             value = [parse_datetime(tm) for tm in self.input.value]
-        except:
+        except Exception:
             raise InvalidParameterValue("Unable to parse the time values entered")
 
         return value

--- a/tests/test_parameter/test_area_parameter.py
+++ b/tests/test_parameter/test_area_parameter.py
@@ -3,9 +3,12 @@ import pytest
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.area_parameter import AreaParameter, area
 
-type_error = ("Input type of <{}> not allowed. Must be one of: "
+type_error = (
+    "Input type of <{}> not allowed. Must be one of: "
     "[<class 'collections.abc.Sequence'>, <class 'str'>, <class "
-    "'roocs_utils.parameter.param_utils.Series'>, <class 'NoneType'>]")
+    "'roocs_utils.parameter.param_utils.Series'>, <class 'NoneType'>]"
+)
+
 
 def test__str__():
     _area = "0.,49.,10.,65"

--- a/tests/test_parameter/test_area_parameter.py
+++ b/tests/test_parameter/test_area_parameter.py
@@ -1,94 +1,103 @@
 import pytest
 
 from roocs_utils.exceptions import InvalidParameterValue
-from roocs_utils.parameter.area_parameter import AreaParameter
+from roocs_utils.parameter.area_parameter import AreaParameter, area
 
+type_error = ("Input type of <{}> not allowed. Must be one of: "
+    "[<class 'collections.abc.Sequence'>, <class 'str'>, <class "
+    "'roocs_utils.parameter.param_utils.Series'>, <class 'NoneType'>]")
 
 def test__str__():
-    area = "0.,49.,10.,65"
-    parameter = AreaParameter(area)
+    _area = "0.,49.,10.,65"
+    parameter = AreaParameter(_area)
+    assert parameter.__str__() == "Area to subset over:" f"\n (0.0, 49.0, 10.0, 65.0)"
+    assert parameter.__repr__() == parameter.__str__()
+    assert parameter.__unicode__() == parameter.__str__()
+
+    _area = area("0.,49.,10.,65")
+    parameter = AreaParameter(_area)
     assert parameter.__str__() == "Area to subset over:" f"\n (0.0, 49.0, 10.0, 65.0)"
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
 
 def test_raw():
-    area = "0.,49.,10.,65"
-    parameter = AreaParameter(area)
-    assert parameter.raw == area
+    _area = area("0.,49.,10.,65")
+    parameter = AreaParameter(_area)
+    assert parameter.raw == _area
 
 
 def test_tuple():
-    area = "0.,49.,10.,65"
-    parameter = AreaParameter(area)
-    assert parameter.tuple == (0.0, 49.0, 10.0, 65)
+    _area = "0.,49.,10.,65"
+    parameter = AreaParameter(_area)
+    assert parameter.value == (0.0, 49.0, 10.0, 65)
 
 
 def test_area_is_tuple_string():
-    area = ("0", "-10", "120", "40")
-    parameter = AreaParameter(area)
-    assert parameter.tuple == (0.0, -10.0, 120.0, 40.0)
+    _area = ("0", "-10", "120", "40")
+    parameter = AreaParameter(_area)
+    assert parameter.value == (0.0, -10.0, 120.0, 40.0)
 
 
 def test_input_list():
-    area = [0, 49.5, 10, 65]
-    parameter = AreaParameter(area)
-    assert parameter.tuple == (0.0, 49.5, 10.0, 65)
+    _area = [0, 49.5, 10, 65]
+    parameter = AreaParameter(_area)
+    assert parameter.value == (0.0, 49.5, 10.0, 65)
 
 
 def test_validate_error_number():
-    area = 0
+    _area = 0
     with pytest.raises(InvalidParameterValue) as exc:
-        AreaParameter(area)
-    assert str(exc.value) == "AreaParameter is not in an accepted format"
+        AreaParameter(_area)
+    assert str(exc.value) == type_error.format("class 'int'")
 
 
 def test_validate_error_words():
-    area = ["test", "area", "error", "words"]
+    _area = ["test", "_area", "error", "words"]
     with pytest.raises(InvalidParameterValue) as exc:
-        AreaParameter(area)
-    assert str(exc.value) == "Area values must be a number"
+        AreaParameter(_area)
+    assert str(exc.value) == "Values must be valid numbers"
 
 
 def test_validate_error_len_1_tuple():
-    area = (0, 65)
+    _area = (0, 65)
     with pytest.raises(InvalidParameterValue) as exc:
-        AreaParameter(area)
+        AreaParameter(_area)
     assert str(exc.value) == "AreaParameter should be of length 4 but is of length 2"
 
 
 def test_asdict():
-    area = "0.,49.,10.,65"
-    parameter = AreaParameter(area)
+    _area = "0.,49.,10.,65"
+    parameter = AreaParameter(_area)
     assert parameter.asdict() == {"lon_bnds": (0, 10), "lat_bnds": (49, 65)}
 
 
 def test_whitespace():
-    area = "0., 49., 10., 65"
-    parameter = AreaParameter(area)
-    assert parameter.tuple == (0.0, 49.0, 10.0, 65)
+    _area = "0., 49., 10., 65"
+    parameter = AreaParameter(_area)
+    assert parameter.value == (0.0, 49.0, 10.0, 65)
 
 
 def test_empty_string():
-    area = ""
-    assert AreaParameter(area).asdict() is None
-    assert AreaParameter(area).tuple is None
+    _area = ""
+    assert AreaParameter(_area).asdict() is None
+    assert AreaParameter(_area).value is None
 
 
 def test_none():
-    area = None
-    assert AreaParameter(area).asdict() is None
-    assert AreaParameter(area).tuple is None
+    _area = None
+    assert AreaParameter(_area).asdict() is None
+    assert AreaParameter(_area).value is None
 
 
 def test_none_2():
-    area = None
-    assert AreaParameter(area).asdict() is None
-    assert AreaParameter(area).tuple is None
+    _area = None
+    assert AreaParameter(_area).asdict() is None
+    assert AreaParameter(_area).value is None
 
 
 def test_class_instance():
-    area = "0.,49.,10.,65"
-    parameter = AreaParameter(area)
+    _area = "0.,49.,10.,65"
+    parameter = AreaParameter(_area)
     new_parameter = AreaParameter(parameter)
-    assert new_parameter.tuple == (0.0, 49.0, 10.0, 65.0)
+    assert new_parameter.value == (0.0, 49.0, 10.0, 65.0)

--- a/tests/test_parameter/test_collection_parameter.py
+++ b/tests/test_parameter/test_collection_parameter.py
@@ -2,43 +2,54 @@ import pytest
 
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.exceptions import MissingParameterValue
-from roocs_utils.parameter.collection_parameter import CollectionParameter
+from roocs_utils.parameter.collection_parameter import CollectionParameter, collection
+
+
+type_error = ("Input type of <{}> not allowed. Must be one of: "
+              "[<class 'collections.abc.Sequence'>, <class 'str'>, <class "
+              "'roocs_utils.parameter.param_utils.Series'>]")
 
 
 def test__str__():
-    collection = [
+    coll = [
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
         "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
     ]
-    parameter = CollectionParameter(collection)
 
-    assert (
-        parameter.__str__() == "Datasets to analyse:"
+    expected_str = ("Datasets to analyse:"
         "\ncmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
-        "\ncmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
-    )
+        "\ncmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga")
 
+    parameter = CollectionParameter(coll)
+    assert parameter.__str__() == expected_str
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
+    coll = collection("cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
+               "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga")
+
+    parameter = CollectionParameter(coll)
+    assert parameter.__str__() == expected_str
+    assert parameter.__repr__() == parameter.__str__()
+    assert parameter.__unicode__() == parameter.__str__()
 
 def test_raw():
-    collection = [
+    coll = [
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
         "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
     ]
-    parameter = CollectionParameter(collection)
-    assert parameter.raw == collection
+    parameter = CollectionParameter(coll)
+    assert parameter.raw == coll
 
 
 def test_validate_error_id():
-    collection = [
+    coll = [
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
         2,
     ]
 
     with pytest.raises(InvalidParameterValue) as exc:
-        CollectionParameter(collection)
+        CollectionParameter(coll)
     assert (
         str(exc.value) == "Each id in a collection must be a string or "
         "an instance of <class 'roocs_utils.utils.file_utils.FileMapper'>"
@@ -46,62 +57,62 @@ def test_validate_error_id():
 
 
 def test_string():
-    collection = (
+    coll = (
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga,"
         "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
     )
 
-    parameter = CollectionParameter(collection)
-    assert parameter.tuple == (
+    parameter = CollectionParameter(coll)
+    assert parameter.value == (
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
         "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
     )
 
 
 def test_one_id():
-    collection = "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
-    parameter = CollectionParameter(collection)
-    assert parameter.tuple == (
+    coll = "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
+    parameter = CollectionParameter(coll)
+    assert parameter.value == (
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
     )
 
 
 def test_whitespace():
-    collection = (
+    coll = (
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga, "
         "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga "
     )
 
-    parameter = CollectionParameter(collection)
-    assert parameter.tuple == (
+    parameter = CollectionParameter(coll)
+    assert parameter.value == (
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
         "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
     )
 
 
 def test_empty_string():
-    collection = ""
+    coll = ""
     with pytest.raises(MissingParameterValue) as exc:
-        CollectionParameter(collection)
+        CollectionParameter(coll)
     assert str(exc.value) == "CollectionParameter must be provided"
 
 
 def test_none():
-    collection = None
+    coll = None
 
-    with pytest.raises(MissingParameterValue) as exc:
-        CollectionParameter(collection)
-    assert str(exc.value) == "CollectionParameter must be provided"
+    with pytest.raises(InvalidParameterValue) as exc:
+        CollectionParameter(coll)
+    assert str(exc.value) == type_error.format("class 'NoneType'")
 
 
 def test_class_instance():
-    collection = (
+    coll = (
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga,"
         "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
     )
-    parameter = CollectionParameter(collection)
+    parameter = CollectionParameter(coll)
     new_parameter = CollectionParameter(parameter)
-    assert new_parameter.tuple == (
+    assert new_parameter.value == (
         "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
         "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
     )

--- a/tests/test_parameter/test_collection_parameter.py
+++ b/tests/test_parameter/test_collection_parameter.py
@@ -5,9 +5,11 @@ from roocs_utils.exceptions import MissingParameterValue
 from roocs_utils.parameter.collection_parameter import CollectionParameter, collection
 
 
-type_error = ("Input type of <{}> not allowed. Must be one of: "
-              "[<class 'collections.abc.Sequence'>, <class 'str'>, <class "
-              "'roocs_utils.parameter.param_utils.Series'>]")
+type_error = (
+    "Input type of <{}> not allowed. Must be one of: "
+    "[<class 'collections.abc.Sequence'>, <class 'str'>, <class "
+    "'roocs_utils.parameter.param_utils.Series'>]"
+)
 
 
 def test__str__():
@@ -16,22 +18,27 @@ def test__str__():
         "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
     ]
 
-    expected_str = ("Datasets to analyse:"
+    expected_str = (
+        "Datasets to analyse:"
         "\ncmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
-        "\ncmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga")
+        "\ncmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga"
+    )
 
     parameter = CollectionParameter(coll)
     assert parameter.__str__() == expected_str
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
-    coll = collection("cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
-               "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga")
+    coll = collection(
+        "cmip5.output1.INM.inmcm4.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
+        "cmip5.output1.MPI-M.MPI-ESM-LR.rcp45.mon.ocean.Omon.r1i1p1.latest.zostoga",
+    )
 
     parameter = CollectionParameter(coll)
     assert parameter.__str__() == expected_str
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
+
 
 def test_raw():
     coll = [

--- a/tests/test_parameter/test_dimension_parameter.py
+++ b/tests/test_parameter/test_dimension_parameter.py
@@ -1,15 +1,25 @@
 import pytest
 
 from roocs_utils.exceptions import InvalidParameterValue
-from roocs_utils.parameter.dimension_parameter import DimensionParameter
+from roocs_utils.parameter.dimension_parameter import DimensionParameter, dimensions
 
 
 def test__str__():
     dims = "time,latitude"
     parameter = DimensionParameter(dims)
-    assert (
-        parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
-    )
+    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    assert parameter.__repr__() == parameter.__str__()
+    assert parameter.__unicode__() == parameter.__str__()
+
+    dims = dimensions("time", "latitude")
+    parameter = DimensionParameter(dims)
+    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    assert parameter.__repr__() == parameter.__str__()
+    assert parameter.__unicode__() == parameter.__str__()
+
+    dims = dimensions("time", "latitude")
+    parameter = DimensionParameter(dims)
+    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
@@ -23,19 +33,19 @@ def test_raw():
 def test_str():
     dims = "time,latitude"
     parameter = DimensionParameter(dims)
-    assert parameter.tuple == ("time", "latitude")
+    assert parameter.value == ("time", "latitude")
 
 
-def test_tuple():
+def test_value():
     dims = ("time", "latitude")
     parameter = DimensionParameter(dims)
-    assert parameter.tuple == ("time", "latitude")
+    assert parameter.value == ("time", "latitude")
 
 
 def test_input_list():
     dims = ["time", "latitude"]
     parameter = DimensionParameter(dims)
-    assert parameter.tuple == ("time", "latitude")
+    assert parameter.value == ("time", "latitude")
 
 
 def test_validate_error_dimension():
@@ -57,26 +67,26 @@ def test_asdict():
 def test_whitespace():
     dims = "time, latitude"
     parameter = DimensionParameter(dims)
-    assert parameter.tuple == ("time", "latitude")
+    assert parameter.value == ("time", "latitude")
 
 
 def test_empty_string():
     dims = ""
     assert DimensionParameter(dims).asdict() is None
-    assert DimensionParameter(dims).tuple is None
+    assert DimensionParameter(dims).value is None
 
 
 def test_none():
     dims = None
     assert DimensionParameter(dims).asdict() is None
-    assert DimensionParameter(dims).tuple is None
+    assert DimensionParameter(dims).value is None
 
 
 def test_class_instance():
     dims = "time"
     parameter = DimensionParameter(dims)
     new_parameter = DimensionParameter(parameter)
-    assert new_parameter.tuple == ("time",)
+    assert new_parameter.value == ("time",)
 
 
 def test_not_a_string():

--- a/tests/test_parameter/test_dimension_parameter.py
+++ b/tests/test_parameter/test_dimension_parameter.py
@@ -7,7 +7,9 @@ from roocs_utils.parameter.dimension_parameter import DimensionParameter, dimens
 def test__str__():
     dims = "time,latitude"
     parameter = DimensionParameter(dims)
-    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    assert (
+        parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    )
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
@@ -20,7 +22,9 @@ def test__str__():
     # Make sequence from args
     dims = dimensions("time", "latitude")
     parameter = DimensionParameter(dims)
-    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    assert (
+        parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    )
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
@@ -34,23 +38,30 @@ def test__str__():
     # Make sequence from comma-separated string
     dims = dimensions("time,latitude")
     parameter = DimensionParameter(dims)
-    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    assert (
+        parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    )
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
     # Make sequence from tuple of values
     dims = dimensions(("time", "latitude"))
     parameter = DimensionParameter(dims)
-    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    assert (
+        parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    )
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
     # Make sequence from list of values
     dims = dimensions(["time", "latitude"])
     parameter = DimensionParameter(dims)
-    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    assert (
+        parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    )
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
+
 
 def test_raw():
     dims = "time,latitude"

--- a/tests/test_parameter/test_dimension_parameter.py
+++ b/tests/test_parameter/test_dimension_parameter.py
@@ -11,18 +11,46 @@ def test__str__():
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
+    dims = "time"
+    parameter = DimensionParameter(dims)
+    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time',)"
+    assert parameter.__repr__() == parameter.__str__()
+    assert parameter.__unicode__() == parameter.__str__()
+
+    # Make sequence from args
     dims = dimensions("time", "latitude")
     parameter = DimensionParameter(dims)
     assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
-    dims = dimensions("time", "latitude")
+    # Make sequence from single arg
+    dims = dimensions("time")
+    parameter = DimensionParameter(dims)
+    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time',)"
+    assert parameter.__repr__() == parameter.__str__()
+    assert parameter.__unicode__() == parameter.__str__()
+
+    # Make sequence from comma-separated string
+    dims = dimensions("time,latitude")
     parameter = DimensionParameter(dims)
     assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
     assert parameter.__repr__() == parameter.__str__()
     assert parameter.__unicode__() == parameter.__str__()
 
+    # Make sequence from tuple of values
+    dims = dimensions(("time", "latitude"))
+    parameter = DimensionParameter(dims)
+    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    assert parameter.__repr__() == parameter.__str__()
+    assert parameter.__unicode__() == parameter.__str__()
+
+    # Make sequence from list of values
+    dims = dimensions(["time", "latitude"])
+    parameter = DimensionParameter(dims)
+    assert parameter.__str__() == "Dimensions to average over:" f"\n ('time', 'latitude')"
+    assert parameter.__repr__() == parameter.__str__()
+    assert parameter.__unicode__() == parameter.__str__()
 
 def test_raw():
     dims = "time,latitude"

--- a/tests/test_parameter/test_level_parameter.py
+++ b/tests/test_parameter/test_level_parameter.py
@@ -4,10 +4,15 @@ import pytest
 
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.level_parameter import LevelParameter
+from roocs_utils.parameter.param_utils import level_interval, level_series
+
+type_err = ("Input type of <{}> not allowed. Must be one of: [<class "
+            "'roocs_utils.parameter.param_utils.Interval'>, "
+            "<class 'roocs_utils.parameter.param_utils.Series'>, <class 'NoneType'>]")
 
 
 def test__str__():
-    level = "1000/2000"
+    level = level_interval("1000/2000")
     parameter = LevelParameter(level)
     assert (
         parameter.__str__() == "Level range to subset over"
@@ -19,7 +24,7 @@ def test__str__():
 
 
 def test_raw():
-    level = "1000/2000"
+    level = level_interval("1000/2000")
     parameter = LevelParameter(level)
     assert parameter.raw == level
 
@@ -28,117 +33,119 @@ def test_validate_error_format():
     level = 1000
     with pytest.raises(InvalidParameterValue) as exc:
         LevelParameter(level)
-    assert str(exc.value) == "LevelParameter is not in an accepted format"
+    assert str(exc.value) == type_err.format("class 'int'")
 
 
 def test_validate_error_len_1_tuple():
-    level = (1000,)
     with pytest.raises(InvalidParameterValue) as exc:
-        LevelParameter(level)
+        level_interval((1000,))
     assert (
         str(exc.value)
-        == "LevelParameter should be a range. Expected 2 values, received 1"
+        == "Interval should be a range. Expected 2 values, received 1"
     )
 
 
 def test_not_numbers():
-    level = (datetime.datetime(2085, 1, 1), datetime.datetime(2120, 12, 30))
+    level = level_interval(datetime.datetime(2085, 1, 1), datetime.datetime(2120, 12, 30))
     with pytest.raises(InvalidParameterValue) as exc:
         LevelParameter(level)
-    assert str(exc.value) == "Level values must be a number"
+    assert str(exc.value) == "Values must be valid numbers"
 
 
 def test_word_string():
-    level = "level/range"
+    level = level_interval("level/range")
     with pytest.raises(InvalidParameterValue) as exc:
         LevelParameter(level)
-    assert str(exc.value) == "Level values must be a number"
+    assert str(exc.value) == "Values must be valid numbers"
 
 
 def test_validate_error_no_slash():
-    level = "1000 2000"
     with pytest.raises(InvalidParameterValue) as exc:
-        LevelParameter(level)
+        level_interval("1000 2000")
     assert (
-        str(exc.value) == "LevelParameter should be passed in as a range separated by /"
+        str(exc.value) == "Interval should be passed in as a range separated by /"
     )
 
 
-def test_tuple():
-    level = "1000/2000"
+def test_start_slash_end():
+    level = level_interval("1000/2000")
     parameter = LevelParameter(level)
-    assert parameter.tuple == (1000, 2000)
+    assert parameter.value == (1000, 2000)
 
 
 def test_float_string():
-    level = "1000.50/2000.60"
+    level = level_interval("1000.50/2000.60")
     parameter = LevelParameter(level)
-    assert parameter.tuple == (1000.5, 2000.6)
+    assert parameter.value == (1000.5, 2000.6)
 
 
 def test_float_tuple():
-    level = (1000.50, 2000.60)
+    level = level_interval(1000.50, 2000.60)
     parameter = LevelParameter(level)
-    assert parameter.tuple == (1000.5, 2000.6)
+    assert parameter.value == (1000.5, 2000.6)
 
 
 def test_string_tuple():
-    level = ("1000.50", "2000.60")
+    level = level_interval("1000.50", "2000.60")
     parameter = LevelParameter(level)
-    assert parameter.tuple == (1000.5, 2000.6)
+    assert parameter.value == (1000.5, 2000.6)
 
 
 def test_int_tuple():
-    level = (1000, 2000)
+    level = level_interval(1000, 2000)
     parameter = LevelParameter(level)
-    assert parameter.tuple == (1000, 2000)
+    assert parameter.value == (1000, 2000)
 
 
 def test_starting_slash():
-    level = "1000/"
+    level = level_interval("1000/")
     parameter = LevelParameter(level)
-    assert parameter.tuple == (1000, None)
+    assert parameter.value == (1000, None)
 
 
 def test_trailing_slash():
-    level = "/2000"
+    level = level_interval("/2000")
     parameter = LevelParameter(level)
-    assert parameter.tuple == (None, 2000)
+    assert parameter.value == (None, 2000)
 
 
 def test_as_dict():
-    level = "1000/2000"
+    level = level_interval("1000/2000")
     parameter = LevelParameter(level)
     assert parameter.asdict() == {"first_level": 1000, "last_level": 2000}
 
 
 def test_slash_none():
-    level = "/"
+    level = level_interval("/")
     parameter = LevelParameter(level)
-    assert parameter.tuple == (None, None)
+    assert parameter.value == None
     assert parameter.asdict() == {"first_level": None, "last_level": None}
 
 
 def test_none():
     level = None
     parameter = LevelParameter(level)
-    assert parameter.tuple == (None, None)
+    assert parameter.value == None
 
 
 def test_empty_string():
-    level = ""
+    level = level_interval("")
     parameter = LevelParameter(level)
-    assert parameter.tuple == (None, None)
+    assert parameter.value == None
+
+    with pytest.raises(InvalidParameterValue) as exc:
+        LevelParameter("")
+    assert str(exc.value) == type_err.format("class 'str'")
 
 
 def test_white_space():
-    level = " 1000 /2000"
+    level = level_interval(" 1000 /2000")
     parameter = LevelParameter(level)
-    assert parameter.tuple == (1000, 2000)
+    assert parameter.value == (1000, 2000)
 
 
 def test_class_instance():
-    level = "1000/2000"
+    level = level_interval("1000/2000")
     parameter = LevelParameter(level)
     new_parameter = LevelParameter(parameter)
-    assert new_parameter.tuple == (1000, 2000)
+    assert new_parameter.value == (1000, 2000)

--- a/tests/test_parameter/test_level_parameter.py
+++ b/tests/test_parameter/test_level_parameter.py
@@ -149,3 +149,16 @@ def test_class_instance():
     parameter = LevelParameter(level)
     new_parameter = LevelParameter(parameter)
     assert new_parameter.value == (1000, 2000)
+
+
+def test_level_series_input():
+    value = [1000, 2000, 3000]
+    vstring = ",".join([str(i) for i in value])
+
+    for lev in (vstring, value, tuple(value)):
+
+        level = level_series(lev)
+        parameter = LevelParameter(level)
+        assert parameter.type == "series"
+        assert parameter.value == value
+        assert parameter.asdict() == {"level_values": value}

--- a/tests/test_parameter/test_level_parameter.py
+++ b/tests/test_parameter/test_level_parameter.py
@@ -6,9 +6,11 @@ from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.level_parameter import LevelParameter
 from roocs_utils.parameter.param_utils import level_interval, level_series
 
-type_err = ("Input type of <{}> not allowed. Must be one of: [<class "
-            "'roocs_utils.parameter.param_utils.Interval'>, "
-            "<class 'roocs_utils.parameter.param_utils.Series'>, <class 'NoneType'>]")
+type_err = (
+    "Input type of <{}> not allowed. Must be one of: [<class "
+    "'roocs_utils.parameter.param_utils.Interval'>, "
+    "<class 'roocs_utils.parameter.param_utils.Series'>, <class 'NoneType'>]"
+)
 
 
 def test__str__():
@@ -39,14 +41,13 @@ def test_validate_error_format():
 def test_validate_error_len_1_tuple():
     with pytest.raises(InvalidParameterValue) as exc:
         level_interval((1000,))
-    assert (
-        str(exc.value)
-        == "Interval should be a range. Expected 2 values, received 1"
-    )
+    assert str(exc.value) == "Interval should be a range. Expected 2 values, received 1"
 
 
 def test_not_numbers():
-    level = level_interval(datetime.datetime(2085, 1, 1), datetime.datetime(2120, 12, 30))
+    level = level_interval(
+        datetime.datetime(2085, 1, 1), datetime.datetime(2120, 12, 30)
+    )
     with pytest.raises(InvalidParameterValue) as exc:
         LevelParameter(level)
     assert str(exc.value) == "Values must be valid numbers"
@@ -62,9 +63,7 @@ def test_word_string():
 def test_validate_error_no_slash():
     with pytest.raises(InvalidParameterValue) as exc:
         level_interval("1000 2000")
-    assert (
-        str(exc.value) == "Interval should be passed in as a range separated by /"
-    )
+    assert str(exc.value) == "Interval should be passed in as a range separated by /"
 
 
 def test_start_slash_end():
@@ -118,20 +117,20 @@ def test_as_dict():
 def test_slash_none():
     level = level_interval("/")
     parameter = LevelParameter(level)
-    assert parameter.value == None
+    assert parameter.value is None
     assert parameter.asdict() == {"first_level": None, "last_level": None}
 
 
 def test_none():
     level = None
     parameter = LevelParameter(level)
-    assert parameter.value == None
+    assert parameter.value is None
 
 
 def test_empty_string():
     level = level_interval("")
     parameter = LevelParameter(level)
-    assert parameter.value == None
+    assert parameter.value is None
 
     with pytest.raises(InvalidParameterValue) as exc:
         LevelParameter("")

--- a/tests/test_parameter/test_time_components_parameter.py
+++ b/tests/test_parameter/test_time_components_parameter.py
@@ -1,0 +1,102 @@
+import pytest
+
+from roocs_utils.exceptions import InvalidParameterValue
+from roocs_utils.parameter.time_components_parameter import (
+    TimeComponentsParameter,
+    time_components,
+    string_to_dict,
+)
+
+
+type_error = (
+    "Input type of <{}> not allowed. Must be one of: "
+    "[<class 'dict'>, <class 'str'>, <class "
+    "'roocs_utils.parameter.param_utils.TimeComponents'>, <class 'NoneType'>]"
+)
+
+
+tc_str = "year:1999,2000,2001|month:12,01,02|hour:00"
+tc_dict = {"year": [1999, 2000, 2001], "month": [12, 1, 2], "hour": [0]}
+tc_dict_month_long_names = {
+    "year": [1999, 2000, 2001],
+    "month": ["December", "January", "February"],
+    "hour": [0],
+}
+tc_dict_short_names = {
+    "year": [1999, 2000, 2001],
+    "month": ["dec", "jan", "feb"],
+    "hour": [0],
+}
+
+
+def test_TimeComponents_class():
+    tc1 = time_components(**string_to_dict(tc_str))
+    tc2 = time_components(**tc_dict)
+    tc3 = time_components(**tc_dict_month_long_names)
+    tc4 = time_components(**tc_dict_short_names)
+
+    assert tc1.value == tc2.value
+    assert tc2.value == tc3.value
+    assert tc2.value == tc4.value
+
+
+def test__str__():
+    parameter = TimeComponentsParameter(tc_str)
+    assert str(parameter).startswith("Time components to select:")
+    assert "month => [12, 1, 2]" in str(parameter)
+
+
+def test_raw():
+    parameter = TimeComponentsParameter(tc_str)
+    assert parameter.raw == tc_str
+
+
+def test_validate_error_id():
+    with pytest.raises(InvalidParameterValue) as exc:
+        TimeComponentsParameter("I am rubbish")
+    assert str(exc.value) == "Cannot create TimeComponentsParameter from: I am rubbish"
+
+
+def test_bad_type_input():
+    with pytest.raises(InvalidParameterValue) as exc:
+        TimeComponentsParameter(34)
+    assert str(exc.value) == type_error.format("class 'int'")
+
+
+def test_dict():
+    for input_dct in (tc_dict, tc_dict_short_names, tc_dict_month_long_names):
+        parameter = TimeComponentsParameter(input_dct)
+        assert parameter.value == tc_dict
+
+
+def test_time_components_input():
+    tc = time_components(**tc_dict)
+    parameter = TimeComponentsParameter(tc)
+    assert parameter.value == tc_dict
+
+
+def test_time_components_with_args():
+    tc = time_components(year=[200, 500], hour="06")
+    assert tc.value["year"] == [200, 500]
+    assert tc.value["hour"] == [6]
+
+
+def test_whitespace():
+    parameter = TimeComponentsParameter(tc_str + "   ")
+    assert parameter.value == tc_dict
+
+
+def test_empty_string():
+    parameter = TimeComponentsParameter("")
+    assert parameter.value is None
+
+
+def test_none():
+    parameter = TimeComponentsParameter(None)
+    assert parameter.value is None
+
+
+def test_class_instance():
+    parameter = TimeComponentsParameter(tc_str)
+    new_parameter = TimeComponentsParameter(parameter)
+    assert new_parameter.value == tc_dict

--- a/tests/test_parameter/test_time_parameter.py
+++ b/tests/test_parameter/test_time_parameter.py
@@ -4,10 +4,17 @@ import pytest
 
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.time_parameter import TimeParameter
+from roocs_utils.parameter.param_utils import (time_interval, time_series,
+                                               time_components)
+
+
+type_err = ("Input type of <{}> not allowed. Must be one of: [<class "
+            "'roocs_utils.parameter.param_utils.Interval'>, "
+            "<class 'roocs_utils.parameter.param_utils.Series'>, <class 'NoneType'>]")
 
 
 def test__str__():
-    time = "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z"
+    time = time_interval("2085-01-01T12:00:00Z/2120-12-30T12:00:00Z")
     parameter = TimeParameter(time)
     assert (
         parameter.__str__() == "Time period to subset over"
@@ -19,18 +26,17 @@ def test__str__():
 
 
 def test_raw():
-    time = "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z"
+    time = time_interval("2085-01-01T12:00:00Z/2120-12-30T12:00:00Z")
     parameter = TimeParameter(time)
     assert parameter.raw == time
 
 
 def test_validate_error_len_1_tuple():
-    time = ("2085-01-01T12:00:00Z",)
     with pytest.raises(InvalidParameterValue) as exc:
-        TimeParameter(time)
+        time_interval(("2085-01-01T12:00:00Z",))
     assert (
         str(exc.value)
-        == "TimeParameter should be a range. Expected 2 values, received 1"
+        == "Interval should be a range. Expected 2 values, received 1"
     )
 
 
@@ -39,45 +45,42 @@ def test_validate_error_datetime():
     time = datetime.datetime(2085, 1, 1)
     with pytest.raises(InvalidParameterValue) as exc:
         TimeParameter(time)
-    assert str(exc.value) == "TimeParameter is not in an accepted format"
+    assert str(exc.value) == type_err.format("class 'datetime.datetime'")
 
 
 def test_datetime_tuple():
-    time = (datetime.datetime(2085, 1, 1), datetime.datetime(2120, 12, 30))
+    time = time_interval(datetime.datetime(2085, 1, 1), datetime.datetime(2120, 12, 30))
     with pytest.raises(InvalidParameterValue) as exc:
         TimeParameter(time)
     assert str(exc.value) == "Unable to parse the time values entered"
 
 
 def test_validate_error_no_slash():
-    time = "2085-01-01T12:00:00Z 2120-12-30T12:00:00Z"
     with pytest.raises(InvalidParameterValue) as exc:
-        TimeParameter(time)
-    assert (
-        str(exc.value) == "TimeParameter should be passed in as a range separated by /"
-    )
+        time_interval("2085-01-01T12:00:00Z 2120-12-30T12:00:00Z")
+    assert str(exc.value) == ("Interval should be passed in as a range separated by /")
 
 
 def test_trailing_slash():
-    time = "2085-01-01T12:00:00Z/"
+    time = time_interval("2085-01-01T12:00:00Z/")
     parameter = TimeParameter(time)
-    assert parameter.tuple == ("2085-01-01T12:00:00+00:00", None)
+    assert parameter.value == ("2085-01-01T12:00:00+00:00", None)
 
 
 def test_starting_slash():
-    time = "/2120-12-30T12:00:00Z"
+    time = time_interval("/2120-12-30T12:00:00Z")
     parameter = TimeParameter(time)
-    assert parameter.tuple == (None, "2120-12-30T12:00:00+00:00")
+    assert parameter.value == (None, "2120-12-30T12:00:00+00:00")
 
 
-def test_tuple():
-    time = "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z"
+def test_start_slash_end():
+    time = time_interval("2085-01-01T12:00:00Z/2120-12-30T12:00:00Z")
     parameter = TimeParameter(time)
-    assert parameter.tuple == ("2085-01-01T12:00:00+00:00", "2120-12-30T12:00:00+00:00")
+    assert parameter.value == ("2085-01-01T12:00:00+00:00", "2120-12-30T12:00:00+00:00")
 
 
 def test_as_dict():
-    time = "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z"
+    time = time_interval("2085-01-01T12:00:00Z/2120-12-30T12:00:00Z")
     parameter = TimeParameter(time)
     assert parameter.asdict() == {
         "start_time": "2085-01-01T12:00:00+00:00",
@@ -86,35 +89,39 @@ def test_as_dict():
 
 
 def test_slash_none():
-    time = "/"
+    time = time_interval("/")
     parameter = TimeParameter(time)
-    assert parameter.tuple == (None, None)
+    assert parameter.value == None
     assert parameter.asdict() == {"start_time": None, "end_time": None}
 
 
 def test_none():
     time = None
     parameter = TimeParameter(time)
-    assert parameter.tuple == (None, None)
+    assert parameter.value == None
 
 
 def test_empty_string():
-    time = ""
+    time = time_interval("")
     parameter = TimeParameter(time)
-    assert parameter.tuple == (None, None)
+    assert parameter.value == None
+
+    with pytest.raises(InvalidParameterValue) as exc:
+        TimeParameter("")
+    assert str(exc.value) == type_err.format("class 'str'")
 
 
 def test_white_space():
-    time = "2085-01-01T12:00:00Z / 2120-12-30T12:00:00Z "
+    time = time_interval("2085-01-01T12:00:00Z / 2120-12-30T12:00:00Z ")
     parameter = TimeParameter(time)
-    assert parameter.tuple == ("2085-01-01T12:00:00+00:00", "2120-12-30T12:00:00+00:00")
+    assert parameter.value == ("2085-01-01T12:00:00+00:00", "2120-12-30T12:00:00+00:00")
 
 
 def test_class_instance():
-    time = "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z"
+    time = time_interval("2085-01-01T12:00:00Z/2120-12-30T12:00:00Z")
     parameter = TimeParameter(time)
     new_parameter = TimeParameter(parameter)
-    assert new_parameter.tuple == (
+    assert new_parameter.value == (
         "2085-01-01T12:00:00+00:00",
         "2120-12-30T12:00:00+00:00",
     )

--- a/tests/test_parameter/test_time_parameter.py
+++ b/tests/test_parameter/test_time_parameter.py
@@ -125,3 +125,17 @@ def test_class_instance():
         "2085-01-01T12:00:00+00:00",
         "2120-12-30T12:00:00+00:00",
     )
+
+
+def test_time_series_input():
+    value = ["2085-01-01T12:00:00Z", "2095-03-03T03:03:03", "2120-12-30T12:00:00Z"]
+    expected_value = [i.replace("Z", "+00:00") for i in value]
+    vstring = ",".join([str(i) for i in value])
+
+    for tm in (vstring, value, tuple(value)):
+
+        times = time_series(tm)
+        parameter = TimeParameter(times)
+        assert parameter.type == "series"
+        assert parameter.value == expected_value
+        assert parameter.asdict() == {"time_values": expected_value}

--- a/tests/test_parameter/test_time_parameter.py
+++ b/tests/test_parameter/test_time_parameter.py
@@ -4,13 +4,18 @@ import pytest
 
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.time_parameter import TimeParameter
-from roocs_utils.parameter.param_utils import (time_interval, time_series,
-                                               time_components)
+from roocs_utils.parameter.param_utils import (
+    time_interval,
+    time_series,
+    time_components,
+)
 
 
-type_err = ("Input type of <{}> not allowed. Must be one of: [<class "
-            "'roocs_utils.parameter.param_utils.Interval'>, "
-            "<class 'roocs_utils.parameter.param_utils.Series'>, <class 'NoneType'>]")
+type_err = (
+    "Input type of <{}> not allowed. Must be one of: [<class "
+    "'roocs_utils.parameter.param_utils.Interval'>, "
+    "<class 'roocs_utils.parameter.param_utils.Series'>, <class 'NoneType'>]"
+)
 
 
 def test__str__():
@@ -34,10 +39,7 @@ def test_raw():
 def test_validate_error_len_1_tuple():
     with pytest.raises(InvalidParameterValue) as exc:
         time_interval(("2085-01-01T12:00:00Z",))
-    assert (
-        str(exc.value)
-        == "Interval should be a range. Expected 2 values, received 1"
-    )
+    assert str(exc.value) == "Interval should be a range. Expected 2 values, received 1"
 
 
 # should datetime objects be allowed?
@@ -91,20 +93,20 @@ def test_as_dict():
 def test_slash_none():
     time = time_interval("/")
     parameter = TimeParameter(time)
-    assert parameter.value == None
+    assert parameter.value is None
     assert parameter.asdict() == {"start_time": None, "end_time": None}
 
 
 def test_none():
     time = None
     parameter = TimeParameter(time)
-    assert parameter.value == None
+    assert parameter.value is None
 
 
 def test_empty_string():
     time = time_interval("")
     parameter = TimeParameter(time)
-    assert parameter.value == None
+    assert parameter.value is None
 
     with pytest.raises(InvalidParameterValue) as exc:
         TimeParameter("")


### PR DESCRIPTION
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #83
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
  - [ ] Need to add Notebook examples
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** 

This is an extension to the existing functionality to enable more sophisticated subsetting in the packages that import `roocs_utils`. There are three main changes:

1. A new `TimeComponentsParameter` has been added...

    The Time Components are any, or none of:
      - year: [list of years]
      - month: [list of months]
      - day: [list of days]
      - hour: [list of hours]
      - minute: [list of minutes]
      - second: [list of seconds]

    `month` is special: you can use either strings or values:
       "feb", "mar" == 2, 3 == "02,03"

    Validates the times input and parses them into a dictionary.

2. The `TimeParameter` can represent an interval or a series:

```
    times = time_interval("2085-01-01T12:00:00Z/2120-12-30T12:00:00Z") # or time_interval("2085-01-01T12:00:00Z/2120-12-30T12:00:00Z", "2085-01-01T12:00:00Z/2120-12-30T12:00:00Z")
    parameter = TimeParameter(times )

or

    times = time_series("2085-01-01T12:00:00Z,2095-03-03T03:03:03,2120-12-30T12:00:00Z") # or time_series("2085-01-01T12:00:00Z", "2095-03-03T03:03:03", "2120-12-30T12:00:00Z")
    parameter = TimeParameter(times )
```

3. The `LevelParameter` can represent an interval or a series:

```
    level = level_interval("1000/2000") # or level_interval(1000, 2000)
    parameter = LevelParameter(level)

or

    level = level_series("1000,2000,3000") # or level_series(1000, 2000, 3000)
    parameter = LevelParameter(level)
```

* **Does this PR introduce a breaking change?:** 

Yes, the changes to the inputs of `LevelParameter` and `TimeParameter` will break any code that calls them. So far, we only know of `clisops`, `daops` and `rook` that use them.
