### PR TITLE
Fix time encoding for mfdataset

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,7 @@ New Features
         cru_ts.4.05.{variable}:cru_ts_4.05/data/{variable}/cru_ts4.05.1901.2*.{variable}.dat.nc.gz
 
   In this example, the `variable` parameter will be expanded out to each of the options provided in the list.
+* The `roocs_utils.xarray_utils.xarray_utils.open_xr_dataset()` function was improved so that the time units are preserved in: `ds.time.encoding["attrs"]`
 
 v0.4.2 (2021-05-18)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,7 +24,7 @@ New Features
         cru_ts.4.05.{variable}:cru_ts_4.05/data/{variable}/cru_ts4.05.1901.2*.{variable}.dat.nc.gz
 
   In this example, the `variable` parameter will be expanded out to each of the options provided in the list.
-* The `roocs_utils.xarray_utils.xarray_utils.open_xr_dataset()` function was improved so that the time units are preserved in: `ds.time.encoding["attrs"]`
+* The ``roocs_utils.xarray_utils.xarray_utils.open_xr_dataset()`` function was improved so that the time units are preserved in: ``ds.time.encoding["attrs"]``
 
 v0.4.2 (2021-05-18)
 -------------------

--- a/roocs_utils/xarray_utils/xarray_utils.py
+++ b/roocs_utils/xarray_utils/xarray_utils.py
@@ -58,7 +58,9 @@ def _get_kwargs_for_opener(otype, **kwargs):
 
     # If single file opener, then remove any multifile args that would raise an
     # exception when called
-    [args.pop(arg) for arg in list(args) if arg in xr.open_dataset.__kwdefaults__]
+    if otype.lower() == "single":
+        [args.pop(arg) for arg in list(args) if arg not in xr.open_dataset.__kwdefaults__]
+
     return args
 
 

--- a/roocs_utils/xarray_utils/xarray_utils.py
+++ b/roocs_utils/xarray_utils/xarray_utils.py
@@ -36,18 +36,7 @@ def _patch_time_encoding(ds, file_list, **kwargs):
         ds.time.encoding["units"] = ds1.time.encoding.get("units", "")
 
 
-
-from xarray.testing import assert_identical
 def open_xr_dataset(dset, **kwargs):
-    ds1 = open_xr_dataset_old(dset, **kwargs)
-    ds2 = open_xr_dasaset_new(dset, **kwargs)
-    assert_identical(ds1, ds2)
-    return ds1 
-
-
-
-
-def open_xr_dataset_new(dset, **kwargs):
     """
     Opens an xarray dataset from a dataset input.
 
@@ -283,3 +272,4 @@ def get_main_variable(ds, exclude_common_coords=True):
         raise Exception("Could not determine main variable")
     else:
         return result
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,11 @@ CMIP5_TAS = os.path.join(
     "master/test_data/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
 )
 
+CMIP5_TAS_EC_EARTH = os.path.join(
+    MINI_ESGF_CACHE_DIR,
+    "master/test_data/badc/cmip5/data/cmip5/output1/ICHEC/EC-EARTH/historical/mon/atmos/Amon/r1i1p1/latest/tas/*.nc",
+)
+
 CMIP5_ZOSTOGA = os.path.join(
     MINI_ESGF_CACHE_DIR,
     "master/test_data/badc/cmip5/data/cmip5/output1/INM/inmcm4/rcp45/mon/ocean/Omon/r1i1p1/latest/zostoga/zostoga_Omon_inmcm4_rcp45_r1i1p1_200601-210012.nc",

--- a/tests/test_xarray_utils/test_open_xr_dataset.py
+++ b/tests/test_xarray_utils/test_open_xr_dataset.py
@@ -1,13 +1,21 @@
 import os
-
+import glob
 import xarray as xr
 
 from roocs_utils.xarray_utils.xarray_utils import open_xr_dataset
-from tests.conftest import C3S_CMIP5_TAS
+from tests.conftest import C3S_CMIP5_TAS, CMIP5_TAS_EC_EARTH
 
 
-def test_open_xr_dataset():
+def test_open_xr_dataset(load_test_data):
     dset = C3S_CMIP5_TAS
-    ds_id = open_xr_dataset(dset)
+    ds = open_xr_dataset(dset)
+    assert isinstance(ds, xr.Dataset)
 
-    assert isinstance(ds_id, xr.Dataset)
+
+def test_open_xr_dataset_retains_time_encoding(load_test_data):
+    dset = CMIP5_TAS_EC_EARTH
+    ds = open_xr_dataset(dset)
+    assert isinstance(ds, xr.Dataset)
+    assert hasattr(ds, "time")
+    assert ds.time.encoding.get("units") == "days since 1850-01-01 00:00:00"
+

--- a/tests/test_xarray_utils/test_open_xr_dataset.py
+++ b/tests/test_xarray_utils/test_open_xr_dataset.py
@@ -19,3 +19,8 @@ def test_open_xr_dataset_retains_time_encoding(load_test_data):
     assert hasattr(ds, "time")
     assert ds.time.encoding.get("units") == "days since 1850-01-01 00:00:00"
 
+    # Now test without our clever opener - to prove time encoding is lost
+    kwargs = {"use_cftime": True, "decode_timedelta": False, "combine": "by_coords"}
+    ds = xr.open_mfdataset(glob.glob(dset), **kwargs)
+    assert ds.time.encoding == {} 
+


### PR DESCRIPTION
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue https://github.com/roocs/roocs-utils/issues/86
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** 

A multi-file dataset has now keeps the time "units" of the first file (if present). This is useful for converting to other formats (e.g. CSV).

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->

No

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->

N/A