### PR TITLE
Parse date strings from any calendar

### DIFF
--- a/roocs_utils/parameter/param_utils.py
+++ b/roocs_utils/parameter/param_utils.py
@@ -1,10 +1,12 @@
-from collections.abc import Sequence
-from dateutil import parser as date_parser
 import calendar
+from collections.abc import Sequence
+
+from dateutil import parser as date_parser
 
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.exceptions import MissingParameterValue
 from roocs_utils.utils.file_utils import FileMapper
+from roocs_utils.utils.time_utils import str_to_AnyCalendarDateTime
 
 
 # Global variables that are generally useful
@@ -72,10 +74,14 @@ def parse_sequence(x, caller):
     return sequence
 
 
-def parse_datetime(dt, default=None):
-    """Parses string to datetime and returns isoformat string for it.
-    If `default` is set, use that in case `dt` is None."""
-    return date_parser.parse(dt, default=default).isoformat()
+# def parse_datetime(dt, default=None):
+#     """Parses string to datetime and returns isoformat string for it.
+#     If `default` is set, use that in case `dt` is None."""
+#     return date_parser.parse(dt, default=default).isoformat()
+
+
+def parse_datetime(dt, defaults=None):
+    return str(str_to_AnyCalendarDateTime(dt, defaults=defaults))
 
 
 class Series:

--- a/roocs_utils/parameter/param_utils.py
+++ b/roocs_utils/parameter/param_utils.py
@@ -74,13 +74,9 @@ def parse_sequence(x, caller):
     return sequence
 
 
-# def parse_datetime(dt, default=None):
-#     """Parses string to datetime and returns isoformat string for it.
-#     If `default` is set, use that in case `dt` is None."""
-#     return date_parser.parse(dt, default=default).isoformat()
-
-
 def parse_datetime(dt, defaults=None):
+    """Parses string to datetime and returns isoformat string for it.
+    If `defaults` is set, use that in case `dt` is None."""
     return str(str_to_AnyCalendarDateTime(dt, defaults=defaults))
 
 

--- a/roocs_utils/parameter/time_parameter.py
+++ b/roocs_utils/parameter/time_parameter.py
@@ -2,14 +2,12 @@ import datetime
 
 from roocs_utils.exceptions import InvalidParameterValue
 from roocs_utils.parameter.base_parameter import _BaseIntervalOrSeriesParameter
-from roocs_utils.parameter.param_utils import (
-    parse_range,
-    parse_sequence,
-    parse_datetime,
-    time_interval,
-    interval,
-    series,
-)
+from roocs_utils.parameter.param_utils import interval
+from roocs_utils.parameter.param_utils import parse_datetime
+from roocs_utils.parameter.param_utils import parse_range
+from roocs_utils.parameter.param_utils import parse_sequence
+from roocs_utils.parameter.param_utils import series
+from roocs_utils.parameter.param_utils import time_interval
 
 
 class TimeParameter(_BaseIntervalOrSeriesParameter):
@@ -36,12 +34,10 @@ class TimeParameter(_BaseIntervalOrSeriesParameter):
         try:
             if start is not None:
                 start = parse_datetime(
-                    start, default=datetime.datetime(datetime.MINYEAR, 1, 1)
+                    start, defaults=[datetime.MINYEAR, 1, 1, 0, 0, 0]
                 )
             if end is not None:
-                end = parse_datetime(
-                    end, default=datetime.datetime(datetime.MAXYEAR, 12, 30)
-                )
+                end = parse_datetime(end, defaults=[datetime.MAXYEAR, 12, 30, 0, 0, 0])
 
         except Exception:
             raise InvalidParameterValue("Unable to parse the time values entered")

--- a/roocs_utils/utils/time_utils.py
+++ b/roocs_utils/utils/time_utils.py
@@ -104,9 +104,9 @@ def str_to_AnyCalendarDateTime(dt, defaults=None):
     :param defaults: (list) The default values to use for year, month, day, hour, minute and second if they cannot be parsed from the string. A default value must be provided for each component. If defaults=None, [-1, 1, 1, 0, 0, 0] is used.
     :return: AnyCalendarDateTime object
     """
-    if len(dt) < 1:
+    if not dt and not defaults:
         raise Exception(
-            "Must provide at least the year as argument to create date time."
+            "Must provide at least the year as argument, or all defaults, to create date time."
         )
 
     # Start with most common pattern

--- a/roocs_utils/utils/time_utils.py
+++ b/roocs_utils/utils/time_utils.py
@@ -94,13 +94,14 @@ class AnyCalendarDateTime:
             self.month = self.MONTH_RANGE[-1]
 
 
-def str_to_AnyCalendarDateTime(dt):
+def str_to_AnyCalendarDateTime(dt, defaults=None):
     """
     Takes a string representing date/time and returns a DateTimeAnyTime object.
     String formats should start with Year and go through to Second, but you
     can miss out anything from month onwards.
 
-    :param dt: string representing a date/time [string]
+    :param dt: (str) string representing a date/time.
+    :param defaults: (list) The default values to use for year, month, day, hour, minute and second if they cannot be parsed from the string. A default value must be provided for each component. If defaults=None, [-1, 1, 1, 0, 0, 0] is used.
     :return: AnyCalendarDateTime object
     """
     if len(dt) < 1:
@@ -116,10 +117,16 @@ def str_to_AnyCalendarDateTime(dt):
         items = match.groups()
     else:
         # Try a more complex split and build of the time string
-        defaults = [-1, 1, 1, 0, 0, 0]
-        components = re.split("[- T:]", dt)
+        if not defaults:
+            defaults = [-1, 1, 1, 0, 0, 0]
+        else:
+            if len(defaults) < 6:
+                raise Exception(
+                    "A default value must be provided for year, month, day, hour, minute and second."
+                )
+        components = re.split("[- T:]", dt.strip("Z"))
 
         # Build a list of time components
         items = components + defaults[len(components) :]
 
-    return AnyCalendarDateTime(*[int(i) for i in items])
+    return AnyCalendarDateTime(*[int(float(i)) for i in items])


### PR DESCRIPTION
Used function `str_to_AnyCalendarDateTime` from `roocs_utils.utils.time_utils` to parse datetimes from any calendar.

Tested with clisops and daops and all tests pass.

Date strings from the time parameter don't have the UTC offset, should I adjust the function to include them, or are they ok without? Do we just assume time is UTC?