### PR TITLE
update c3s-cordex config

### DIFF
--- a/roocs_utils/etc/roocs.ini
+++ b/roocs_utils/etc/roocs.ini
@@ -107,6 +107,7 @@ data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_
 [project:c3s-cordex]
 project_name = c3s-cordex
 base_dir = /gws/nopw/j04/cp4cds1_vol1/data/c3s-cordex
+is_default_for_path = True
 file_name_template = {__derive__var_id}_{CORDEX_domain}_{driving_model_id}_{experiment_id}_{driving_model_ensemble_member}_{model_id}_{rcm_version_id}_{frequency}{__derive__time_range}{extra}.{__derive__extension}
 attr_defaults =
     CORDEX_domain:no-domain
@@ -119,7 +120,7 @@ attr_defaults =
 facet_rule = project product domain institute driving_model experiment_id ensemble rcm_name rcm_version time_frequency variable version
 mappings =
     project:project_id
-use_catalog = False
+use_catalog = True
 
 
 [environment]


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
Updated to have ``is_default_for_path = True`` and ``use_catalog = True``

Do we also need a ``data_node_root`` such as the c3s-cmip6 one:
``data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6/`` ?