### PR TITLE
added c3s-cmip-decadal project to default roocs.ini

### DIFF
--- a/roocs_utils/etc/roocs.ini
+++ b/roocs_utils/etc/roocs.ini
@@ -105,6 +105,28 @@ mappings =
 use_catalog = True
 data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6/
 
+[project:c3s-cmip6-decadal]
+project_name = c3s-cmip6-decadal
+base_dir = /badc/cmip6/data/CMIP6
+is_default_for_path = True
+# these may need to be changed
+file_name_template = {__derive__var_id}_{table_id}_{source_id}_{experiment_id}_r{realization_index}i{initialization_index}p{physics_index}f{forcing_index}_{grid_label}{__derive__time_range}{extra}.{__derive__extension}
+attr_defaults =
+    table_id:no-table
+    source_id:no-model
+    experiment_id:no-expt
+    realization_index:X
+    initialization_index:X
+    physics_index:X
+    forcing_index:X
+    grid_label:no-grid
+facet_rule = mip_era activity_id institution_id source_id experiment_id member_id table_id variable_id grid_label version
+mappings =
+    project:mip_era
+use_catalog = True
+data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cmip6/
+
+
 [project:c3s-cordex]
 project_name = c3s-cordex
 base_dir = /gws/nopw/j04/cp4cds1_vol1/data/c3s-cordex


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [ ] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
Update the default `roocs.ini` config with the project `c3s-cmip6-decadal`.

The `c3s-cmip6-decadal` is a copy of `c3s-cmip6`. Only the prefix is different. The CMIP6 decadal datasets are provided in a separate catalog than the cmip6 datasets.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
no

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->

See also PR: https://github.com/cp4cds/c3s_34g_manifests/pull/34
