### PR TITLE
added realization dimension

### DIFF
--- a/roocs_utils/xarray_utils/xarray_utils.py
+++ b/roocs_utils/xarray_utils/xarray_utils.py
@@ -10,7 +10,7 @@ import xarray as xr
 
 from roocs_utils.project_utils import dset_to_filepaths
 
-known_coord_types = ["time", "level", "latitude", "longitude"]
+known_coord_types = ["time", "level", "latitude", "longitude", "realization"]
 
 
 def _patch_time_encoding(ds, file_list, **kwargs):
@@ -200,6 +200,22 @@ def is_time(coord):
     return False
 
 
+def is_realization(coord):
+    """
+    Determines if a coordinate is realization.
+
+    :param coord: coordinate of xarray dataset e.g. coord = ds.coords[coord_id]
+    :return: (bool) True if the coordinate is longitude.
+    """
+    if "realization" in coord.cf and coord.cf["realization"].name == coord.name:
+        return True
+
+    if coord.attrs.get("standard_name", None) == "realization":
+        return True
+
+    return False
+
+
 def get_coord_type(coord):
     """
     Gets the coordinate type.
@@ -216,6 +232,8 @@ def get_coord_type(coord):
         return "level"
     elif is_time(coord):
         return "time"
+    elif is_realization(coord):
+        return "realization"
 
     return None
 
@@ -228,7 +246,13 @@ def convert_coord_to_axis(coord):
     :return: (str) The single character axis identifier of the coordinate (tzyx).
     """
 
-    axis_dict = {"time": "t", "longitude": "x", "latitude": "y", "level": "z"}
+    axis_dict = {
+        "time": "t",
+        "longitude": "x",
+        "latitude": "y",
+        "level": "z",
+        "realization": "r",
+    }
     return axis_dict.get(coord, None)
 
 
@@ -283,7 +307,7 @@ def get_main_variable(ds, exclude_common_coords=True):
     flat_dims = [dim for sublist in data_dims for dim in sublist]
 
     results = {}
-    common_coords = ["bnd", "bound", "lat", "lon", "time", "level"]
+    common_coords = ["bnd", "bound", "lat", "lon", "time", "level", "realization_index"]
 
     for var_id, data in ds.variables.items():
 

--- a/tests/test_parameter/test_dimension_parameter.py
+++ b/tests/test_parameter/test_dimension_parameter.py
@@ -1,7 +1,8 @@
 import pytest
 
 from roocs_utils.exceptions import InvalidParameterValue
-from roocs_utils.parameter.dimension_parameter import DimensionParameter, dimensions
+from roocs_utils.parameter.dimension_parameter import DimensionParameter
+from roocs_utils.parameter.dimension_parameter import dimensions
 
 
 def test__str__():
@@ -93,7 +94,7 @@ def test_validate_error_dimension():
         DimensionParameter(dims)
     assert (
         str(exc.value)
-        == "Dimensions for averaging must be one of ['time', 'level', 'latitude', 'longitude']"
+        == "Dimensions for averaging must be one of ['time', 'level', 'latitude', 'longitude', 'realization']"
     )
 
 


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
New feature: 

this PR adds a new dimension `realization_index` with standard name `realization` to the known coordinates. 

The change is necessary to work with CMIP6 decadal datasets. In Copernicus we want to use the `average_over_dim` operator to merge the 10 realization members of each CMIP6 decadal dataset.

The notebook example with concat (new) + average operator:
https://nbviewer.org/github/roocs/rooki/blob/master/notebooks/demo/demo-rooki-concat.ipynb

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
no

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->
