### PR TITLE
Add further configuration for ATLAS projects

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,8 @@ Co-Developers
 * Eleanor Smith eleanor.smith@stfc.ac.uk `@ellesmith88 <https://github.com/ellesmith88>`_
 * Carsten Ehbrecht ehbrecht@dkrz.de
 * Pascal Bourgault pascal.bourgault@gmail.com
+
+Contributors
+------------
+
+* Martin Schupfner <schupfner@dkrz.de> `@sol1105 <https://github.com/sol1105>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,14 @@ Next
 
 * ...
 
+
+v0.6.7 (unreleased)
+-------------------
+
+Other Changes
+^^^^^^^^^^^^^
+* Updated `roocs.ini` default values for atlas datasets for further methods of how to infer the project name (#113).
+
 v0.6.6 (2024-01-26)
 -------------------
 

--- a/roocs_utils/etc/roocs.ini
+++ b/roocs_utils/etc/roocs.ini
@@ -146,6 +146,20 @@ mappings =
 use_catalog = True
 data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cordex/
 
+[project:c3s-ipcc-atlas]
+base_dir = /pool/data/c3s-ipcc-ar6-atlas
+use_inventory = True
+use_catalog = True
+is_default_for_path = True
+file_name_template = {__derive__var_id}_{source}_{experiment_id}_{frequency}{__derive__time_range}{extra}.{__derive__extension}
+attr_defaults =
+    frequency:no-freq
+    experiment_id:no-expt
+facet_rule = variable project experiment time_frequency
+mappings =
+    project:project_id
+data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-ipcc-atlas/
+
 [project:c3s-ipcc-ar6-atlas]
 base_dir = /pool/data/c3s-ipcc-ar6-atlas
 use_inventory = True

--- a/roocs_utils/etc/roocs.ini
+++ b/roocs_utils/etc/roocs.ini
@@ -146,7 +146,7 @@ mappings =
 use_catalog = True
 data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cordex/
 
-[project:c3s-ipcc-atlas]
+[project:c3s-ipcc-ar6-atlas]
 base_dir = /pool/data/c3s-ipcc-ar6-atlas
 use_inventory = True
 use_catalog = True
@@ -158,6 +158,20 @@ attr_defaults =
 facet_rule = variable project experiment time_frequency
 mappings =
     project:project_id
+data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-ipcc-atlas/
+
+[project:ipcc-ar6-interactive-atlas-dataset]
+base_dir = /pool/data/c3s-ipcc-ar6-atlas
+use_inventory = True
+use_catalog = True
+is_default_for_path = True
+file_name_template = {__derive__var_id}_{source}_{experiment_id}_{frequency}{__derive__time_range}{extra}.{__derive__extension}
+attr_defaults =
+    frequency:no-freq
+    experiment_id:no-expt
+facet_rule = variable project experiment time_frequency
+mappings =
+    project:product
 data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-ipcc-atlas/
 
 [project:c3s-cica-atlas]
@@ -174,6 +188,19 @@ mappings =
     project:project_id
 data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cica-atlas/
 
+[project:copernicus -interactive-climate-atlas-dataset]
+base_dir = /pool/data/c3s-cica-atlas
+use_inventory = True
+use_catalog = True
+is_default_for_path = True
+file_name_template = {__derive__var_id}_{source}_{experiment_id}_{frequency}{__derive__time_range}{extra}.{__derive__extension}
+attr_defaults =
+    frequency:no-freq
+    experiment_id:no-expt
+facet_rule = variable project experiment time_frequency
+mappings =
+    project:product
+data_node_root = https://data.mips.copernicus-climate.eu/thredds/fileServer/esg_c3s-cica-atlas/
 
 [environment]
 OMP_NUM_THREADS=1

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -63,6 +63,21 @@ def test_get_project_name(load_test_data):
     project = get_project_name(dset)
     assert project == "c3s-cica-atlas"
 
+    # c3s-cica-atlas 2
+    dset = "/pool/data/c3s-cica-atlas/ERA5/psl_ERA5_mon_194001-202212.nc"
+    project = get_project_name(dset)
+    assert project == "c3s-cica-atlas"
+
+    # c3s-ipcc-ar6-atlas
+    dset = "c3s-ipcc-ar6-atlas.t.CORDEX-ANT.rcp45.mon"
+    project = get_project_name(dset)
+    assert project == "c3s-ipcc-ar6-atlas"
+
+    # c3s-ipcc-ar6-atlas
+    dset = "/pool/data/c3s-ipcc-ar6-atlas/CORDEX-ANT/rcp45/pr_CORDEX-ANT_rcp45_mon_200601-210012.nc"
+    project = get_project_name(dset)
+    assert project == "c3s-ipcc-ar6-atlas"
+
 
 def test_get_project_name_badc():
     dset = "/badc/cmip5/data/cmip5/output1/MOHC/HadGEM2-ES/rcp85/mon/atmos/Amon/r1i1p1/latest/tas/*.nc"
@@ -206,6 +221,12 @@ def test_derive_dset():
     ds_id = derive_dset(dset)
 
     assert ds_id == "/pool/data/c3s-cica-atlas/cd/CMIP6/historical/yr"
+
+    # c3s-ipcc-ar6-atlas
+    dset = "c3s-ipcc-ar6-atlas.cd.CMIP6.historical.yr"
+    ds_id = derive_dset(dset)
+
+    assert ds_id == "/pool/data/c3s-ipcc-ar6-atlas/cd/CMIP6/historical/yr"
 
 
 def test_switch_dset():

--- a/tests/test_project_utils.py
+++ b/tests/test_project_utils.py
@@ -58,6 +58,12 @@ def test_get_project_name(load_test_data):
     project = get_project_name(dset)
     assert project == "c3s-cmip6-decadal"
 
+    # TODO: This needs to be cleaned up by introducing aliases and/or multiple mapping facets.
+    #       Each project should be defined only once in the roocs.ini.
+    #       Currently, without the possibility to define aliases, this is not possible
+    #       for the ATLAS projects, because the web prefix, the project name in the DRS and the
+    #       project name in the netCDF metadata differ from one another ...
+    #
     # c3s-cica-atlas
     dset = "c3s-cica-atlas.cd.CMIP6.historical.yr"
     project = get_project_name(dset)
@@ -76,7 +82,7 @@ def test_get_project_name(load_test_data):
     # c3s-ipcc-ar6-atlas
     dset = "/pool/data/c3s-ipcc-ar6-atlas/CORDEX-ANT/rcp45/pr_CORDEX-ANT_rcp45_mon_200601-210012.nc"
     project = get_project_name(dset)
-    assert project == "c3s-ipcc-ar6-atlas"
+    assert project in ["c3s-ipcc-ar6-atlas", "c3s-ipcc-atlas"]
 
 
 def test_get_project_name_badc():


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes issue #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] HISTORY.rst has been updated (with summary of main changes)
- [x] I have added my relevant user information to `AUTHORS.md`

* **What kind of change does this PR introduce?:** <!--(Bug fix, feature, docs update, etc.)-->
I added/corrected project descriptions for the ATLAS projects. This is necessary to identify the ATLAS projects via the netCDF metadata.

* **Does this PR introduce a breaking change?:** <!--(Has there been an API change? New dependencies?)-->
Not to my best knowledge.

* **Other information:** <!--(Relevant discussion threads? Outside documentation pages?)-->

I added the necessary project description so the ATLAS projects can be determined from the netCDF metadata.
The ATLAS datasets have each 3 different project strings defined (sigh):

**ATLAS v0 / c3s-ipcc-ar6-atlas:**
* in file-path: **c3s-ipcc-ar6-atlas**
* in metadata:
  * `:project = "IPCC-WGI AR6 Atlas" ;`
  * `:product = "ipcc-ar6-interactive-atlas-dataset" ;`

**ATLAS v1 / c3s-cica-atlas:**
* in file-path: **c3s-cica-atlas**
* In metadata:
  * `:project = "Copernicus Interactive Climate Atlas" ;`
  * `:product = "copernicus -interactive-climate-atlas-dataset" ;`
  ( notice the space between `"copernicus"` and `"-Interactive-climate-atlas-dataset"` - likely a typo from when creating the files?!)

Therefore I defined two new projects in the `roocs.ini` labeled with whatever is defined as `product` in the ATLAS metadata and set the mapper to `product` rather than `project_id`. I copied all other settings from the original project definitions. `clisops` is then able to detect the project without problems. I do not know if all this could have been achieved easier, but I am not aware of the possibility to define aliases for project names or multiple mappings for `project`.